### PR TITLE
[SD-1422] Clenup locks when sessions are removed

### DIFF
--- a/apps/auth/auth.py
+++ b/apps/auth/auth.py
@@ -15,6 +15,7 @@ import flask
 from superdesk.resource import Resource
 from superdesk.errors import SuperdeskApiError
 from superdesk import get_resource_service, get_resource_privileges, get_intrinsic_privileges
+import superdesk
 
 
 logger = logging.getLogger(__name__)
@@ -57,10 +58,13 @@ class AuthResource(Resource):
         },
         'user': Resource.rel('users', True)
     }
-    resource_methods = ['POST']
+    resource_methods = ['POST', 'DELETE']
     item_methods = ['GET', 'DELETE']
-    public_methods = ['POST']
+    public_methods = ['POST', 'DELETE']
     extra_response_fields = ['user', 'token', 'username']
+
+
+superdesk.intrinsic_privilege('auth', method=['DELETE'])
 
 
 class SuperdeskTokenAuth(TokenAuth):

--- a/apps/auth/auth.py
+++ b/apps/auth/auth.py
@@ -58,7 +58,7 @@ class AuthResource(Resource):
         },
         'user': Resource.rel('users', True)
     }
-    resource_methods = ['POST', 'DELETE']
+    resource_methods = ['POST']
     item_methods = ['GET', 'DELETE']
     public_methods = ['POST', 'DELETE']
     extra_response_fields = ['user', 'token', 'username']

--- a/apps/auth/db/db.py
+++ b/apps/auth/db/db.py
@@ -12,8 +12,7 @@ import bcrypt
 from apps.auth.service import AuthService
 from superdesk import get_resource_service
 from superdesk.errors import CredentialsAuthError
-from apps.common.components.utils import get_component
-from apps.item_lock.components.item_lock import ItemLock
+from flask import current_app as app
 
 
 class DbAuthService(AuthService):
@@ -43,17 +42,5 @@ class DbAuthService(AuthService):
         :param doc: A deleted auth doc AKA a session
         :return:
         '''
-        print('deleting locks for session {}'.format(doc['_id']))
-        # need to relinquish all locks for this session
-        get_component(ItemLock).unlock_session(doc['user'], doc['_id'])
-
-    def delete_all(self, query):
-        '''
-        :param query: a query that will find all sessions (auth records) that match the query
-        :return:
-        '''
-        print('delete sessions matching {}'.format(query))
-        sessions = get_resource_service('auth').get(req=None, lookup=query)
-        for session in sessions:
-            print('session {}'.format(session['_id']))
-            get_resource_service('auth').delete_action({'_id': str(session['_id'])})
+        # notify that the session has ended
+        app.on_session_end(doc['user'], doc['_id'])

--- a/apps/auth/db/db.py
+++ b/apps/auth/db/db.py
@@ -12,6 +12,8 @@ import bcrypt
 from apps.auth.service import AuthService
 from superdesk import get_resource_service
 from superdesk.errors import CredentialsAuthError
+from apps.common.components.utils import get_component
+from apps.item_lock.components.item_lock import ItemLock
 
 
 class DbAuthService(AuthService):
@@ -35,3 +37,23 @@ class DbAuthService(AuthService):
             raise CredentialsAuthError(credentials)
 
         return user
+
+    def on_deleted(self, doc):
+        '''
+        :param doc: A deleted auth doc AKA a session
+        :return:
+        '''
+        print('deleting locks for session {}'.format(doc['_id']))
+        # need to relinquish all locks for this session
+        get_component(ItemLock).unlock_session(doc['user'], doc['_id'])
+
+    def delete_all(self, query):
+        '''
+        :param query: a query that will find all sessions (auth records) that match the query
+        :return:
+        '''
+        print('delete sessions matching {}'.format(query))
+        sessions = get_resource_service('auth').get(req=None, lookup=query)
+        for session in sessions:
+            print('session {}'.format(session['_id']))
+            get_resource_service('auth').delete_action({'_id': str(session['_id'])})

--- a/apps/auth/db/db.py
+++ b/apps/auth/db/db.py
@@ -12,7 +12,7 @@ import bcrypt
 from apps.auth.service import AuthService
 from superdesk import get_resource_service
 from superdesk.errors import CredentialsAuthError
-from flask import current_app as app
+from flask import g, current_app as app
 
 
 class DbAuthService(AuthService):
@@ -44,3 +44,10 @@ class DbAuthService(AuthService):
         '''
         # notify that the session has ended
         app.on_session_end(doc['user'], doc['_id'])
+
+    def is_authorized(self, **kwargs):
+        if kwargs.get("user_id") is None:
+            return False
+
+        auth = self.find_one(_id=kwargs.get("user_id"), req=None)
+        return str(g.auth['_id']) == str(auth.get("_id"))

--- a/apps/auth/session_purge.py
+++ b/apps/auth/session_purge.py
@@ -12,6 +12,7 @@ from superdesk import app
 from datetime import timedelta
 from superdesk.utc import utcnow
 from eve.utils import date_to_str
+import superdesk
 
 
 class RemoveExpiredSessions():
@@ -24,4 +25,4 @@ class RemoveExpiredSessions():
         expiration_time = utcnow() - timedelta(minutes=expiry_minutes)
         print('Deleting session not updated since {}'.format(expiration_time))
         query = {'_updated': {'$lte': date_to_str(expiration_time)}}
-        app.data.remove('auth', query)
+        superdesk.get_resource_service('auth').delete_all(query)

--- a/apps/item_lock/components/item_lock.py
+++ b/apps/item_lock/components/item_lock.py
@@ -28,6 +28,7 @@ TASK = 'task'
 class ItemLock(BaseComponent):
     def __init__(self, app):
         self.app = app
+        self.app.on_session_end += self.on_session_end
 
     @classmethod
     def name(cls):
@@ -92,7 +93,6 @@ class ItemLock(BaseComponent):
         items = item_model.find({'lock_session': session_id})
 
         for item in items:
-            print('unlocking item id {} from session {}'.format(item['_id'], session_id))
             self.unlock({'_id': item['_id']}, user_id, session_id, None)
 
     def can_lock(self, item, user_id, session_id):
@@ -127,3 +127,6 @@ class ItemLock(BaseComponent):
             return False, error_message
 
         return True, ''
+
+    def on_session_end(self, user_id, session_id):
+        self.unlock_session(user_id, session_id)

--- a/apps/item_lock/components/item_lock.py
+++ b/apps/item_lock/components/item_lock.py
@@ -19,7 +19,6 @@ from apps.common.models.utils import get_model
 from apps.users.services import current_user_has_privilege
 import superdesk
 
-
 LOCK_USER = 'lock_user'
 LOCK_SESSION = 'lock_session'
 STATUS = '_status'
@@ -87,6 +86,14 @@ class ItemLock(BaseComponent):
 
         item = item_model.find_one(item_filter)
         return item
+
+    def unlock_session(self, user_id, session_id):
+        item_model = get_model(ItemModel)
+        items = item_model.find({'lock_session': session_id})
+
+        for item in items:
+            print('unlocking item id {} from session {}'.format(item['_id'], session_id))
+            self.unlock({'_id': item['_id']}, user_id, session_id, None)
 
     def can_lock(self, item, user_id, session_id):
         """

--- a/features/auth.feature
+++ b/features/auth.feature
@@ -163,10 +163,10 @@ Feature: Authentication
         When we delete latest
         Then we get response code 204
 
-    Scenario: user logs in locks content and logs out
+    Scenario: user logs in locks content and logs out logs in again and the content is no longer locked
         Given "users"
             """
-            [{"username": "foo", "password": "bar", "email": "foo@bar.org", "is_active": true}]
+            [{"username": "foo", "password": "bar", "email": "foo@bar.org", "is_active": true, "user_type": "administrator"}]
             """
         When we post to auth
         """
@@ -185,3 +185,11 @@ Feature: Authentication
         {}
         """
         Then we get response code 204
+        When we post to auth
+        """
+        {"username": "foo", "password": "bar"}
+        """
+        When we get "/archive"
+        Then item "item-1" is unlocked
+
+

--- a/features/auth.feature
+++ b/features/auth.feature
@@ -16,7 +16,7 @@ Feature: Authentication
         And we get "user"
         And we get no "password"
 
-	
+
 	Scenario: Change user password with success
         Given "users"
         """
@@ -35,7 +35,7 @@ Feature: Authentication
         Then we get "token"
         And we get "user"
         And we get no "password"
-        
+
 
 	Scenario: Change user password with wrong old password
         Given "users"
@@ -50,9 +50,9 @@ Feature: Authentication
         Then we get error 401
         """
         {"_message": "The provided old password is not correct.", "_status": "ERR"}
-        """        
-        
-        
+        """
+
+
 	Scenario: Reset password existing user
         Given "users"
         """
@@ -88,7 +88,7 @@ Feature: Authentication
             """
 
         Then we fail to reset password for user
- 
+
     Scenario: Authenticate with wrong password returns error
         Given "users"
             """
@@ -149,3 +149,39 @@ Feature: Authentication
             """
 
         And we get "Access-Control-Allow-Origin" header
+
+    Scenario: user logs in and out
+        Given "users"
+            """
+            [{"username": "foo", "password": "bar", "email": "foo@bar.org", "is_active": true}]
+            """
+
+        When we post to auth
+            """
+            {"username": "foo", "password": "bar"}
+            """
+        When we delete latest
+        Then we get response code 204
+
+    Scenario: user logs in locks content and logs out
+        Given "users"
+            """
+            [{"username": "foo", "password": "bar", "email": "foo@bar.org", "is_active": true}]
+            """
+        When we post to auth
+        """
+        {"username": "foo", "password": "bar"}
+        """
+        Given "archive"
+        """
+        [{"_id": "item-1", "guid": "item-1", "headline": "test"}]
+        """
+        When we post to "/archive/item-1/lock"
+        """
+        {}
+        """
+        When we delete "/auth/#AUTH_ID#"
+        """
+        {}
+        """
+        Then we get response code 204

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -18,6 +18,7 @@ from eve.methods.common import parse
 from superdesk import default_user_preferences, get_resource_service, utc
 from superdesk.utc import utcnow
 from eve.io.mongo import MongoJSONEncoder
+from base64 import b64encode
 
 from wooper.general import fail_and_print_body, apply_path,\
     parse_json_response
@@ -246,6 +247,12 @@ def step_impl_given_user_type(context, user_type):
 def step_impl_when_auth(context):
     data = context.text
     context.response = context.client.post(get_prefixed_url(context.app, '/auth'), data=data, headers=context.headers)
+    if context.response.status_code == 200 or context.response.status_code == 201:
+        item = json.loads(context.response.get_data())
+        if item.get('_id'):
+            set_placeholder(context, 'AUTH_ID', item['_id'])
+        context.headers.append(('Authorization', b'basic ' + b64encode(item['token'].encode('ascii') + b':')))
+        context.user = item['user']
 
 
 @when('we fetch from "{provider_name}" ingest "{guid}"')


### PR DESCRIPTION
This change should remove the locks from any content when the session is removed ('auth' is deleted), either by the user logging out or by the session garbage collection.

It seems that the 'DELETE' sent by the client when you click on 'sign out' does not get to the server, this should be fixed as well.

I still need to write some behave tests to test the 'DELETE' to the 'auth'

Feel free to comment