### PR TITLE
fix(stages) - Using global expiry as default for stages and removed desk level content expiry

### DIFF
--- a/apps/archive/common.py
+++ b/apps/archive/common.py
@@ -185,10 +185,8 @@ def is_assigned_to_a_desk(doc):
     return doc.get('task') and doc['task'].get('desk')
 
 
-def get_item_expiry(app, desk, stage):
+def get_item_expiry(app, stage):
     expiry_minutes = app.settings['CONTENT_EXPIRY_MINUTES']
-    if desk:
-        expiry_minutes = desk.get('content_expiry', expiry_minutes)
     if stage:
         expiry_minutes = stage.get('content_expiry', expiry_minutes)
 
@@ -197,7 +195,7 @@ def get_item_expiry(app, desk, stage):
 
 def get_expiry(desk_id=None, stage_id=None):
 
-    desk = stage = None
+    stage = None
     if desk_id:
         desk = superdesk.get_resource_service('desks').find_one(req=None, _id=desk_id)
 
@@ -216,7 +214,7 @@ def get_expiry(desk_id=None, stage_id=None):
         if not stage:
                 raise SuperdeskApiError.notFoundError('Invalid stage identifier %s' % stage_id)
 
-    return get_item_expiry(app=app, desk=desk, stage=stage)
+    return get_item_expiry(app=app, stage=stage)
 
 
 def set_item_expiry(update, original):

--- a/apps/desks.py
+++ b/apps/desks.py
@@ -33,9 +33,6 @@ desks_schema = {
         }
     },
     'incoming_stage': Resource.rel('stages', True),
-    'content_expiry': {
-        'type': 'integer'
-    },
     'spike_expiry': {
         'type': 'integer'
     }

--- a/apps/stages.py
+++ b/apps/stages.py
@@ -36,8 +36,7 @@ class StagesResource(Resource):
             'minlength': 1
         },
         'description': {
-            'type': 'string',
-            'minlength': 1
+            'type': 'string'
         },
         'default_incoming': {
             'type': 'boolean',

--- a/apps/tasks_tests.py
+++ b/apps/tasks_tests.py
@@ -28,22 +28,14 @@ class TasksTestCase(TestCase):
         return test_settings
 
     def test_get_global_content_expiry(self):
-        calculated_minutes = get_item_expiry(self.app, None, None)
+        calculated_minutes = get_item_expiry(self.app, None)
         reference_minutes = get_expiry_date(99)
         self.assertEquals(calculated_minutes.hour, reference_minutes.hour)
         self.assertEquals(calculated_minutes.minute, reference_minutes.minute)
 
-    def test_get_desk_content_expiry(self):
-        desk = {"content_expiry": 50}
-        calculated_minutes = get_item_expiry(self.app, desk, None)
-        reference_minutes = get_expiry_date(50)
-        self.assertEquals(calculated_minutes.hour, reference_minutes.hour)
-        self.assertEquals(calculated_minutes.minute, reference_minutes.minute)
-
     def test_get_stage_content_expiry(self):
-        desk = {"content_expiry": 50}
         stage = {"content_expiry": 10}
-        calculated_minutes = get_item_expiry(self.app, desk, stage)
+        calculated_minutes = get_item_expiry(self.app, stage)
         reference_minutes = get_expiry_date(10)
         self.assertEquals(calculated_minutes.hour, reference_minutes.hour)
         self.assertEquals(calculated_minutes.minute, reference_minutes.minute)

--- a/features/archive.feature
+++ b/features/archive.feature
@@ -173,7 +173,7 @@ Feature: News Items Archive
     Scenario: Browse public content
         Given "desks"
         """
-        [{"name": "Sports Desk", "spike_expiry": 60, "content_expiry":10}]
+        [{"name": "Sports Desk", "spike_expiry": 60}]
         """
         Given "archive"
             """
@@ -183,7 +183,7 @@ Feature: News Items Archive
         Then we get list with 1 items
 
         When we get "archive/testid1"
-        Then we get content expiry 10
+        Then we get global content expiry
 
     @auth
     @ticket-sd-360

--- a/features/content_spike.feature
+++ b/features/content_spike.feature
@@ -70,7 +70,7 @@ Feature: Content Spiking
         Given empty "stages"
         Given "desks"
         """
-        [{"name": "Sports Desk", "spike_expiry": 60, "content_expiry":10}]
+        [{"name": "Sports Desk", "spike_expiry": 60}]
         """
         Given "archive"
         """
@@ -80,4 +80,4 @@ Feature: Content Spiking
         And we unspike "item-1"
         Then we get unspiked content "item-1"
         And we get version 3
-        And we get content expiry 10
+        And we get global content expiry

--- a/features/search.feature
+++ b/features/search.feature
@@ -13,7 +13,7 @@ Feature: Search Feature
     Scenario: Can search archive
         Given "desks"
         """
-        [{"name": "Sports Desk", "spike_expiry": 60, "content_expiry":10}]
+        [{"name": "Sports Desk", "spike_expiry": 60}]
         """
         Given "archive"
             """
@@ -35,7 +35,7 @@ Feature: Search Feature
     Scenario: Can limit search to 1 result per shard
         Given "desks"
         """
-        [{"name": "Sports Desk", "spike_expiry": 60, "content_expiry":10}]
+        [{"name": "Sports Desk", "spike_expiry": 60}]
         """
         Given "archive"
             """

--- a/features/stages.feature
+++ b/features/stages.feature
@@ -168,6 +168,41 @@ Feature: Stages
         When we get "archive/testid1"
         Then we get content expiry 20
 
+    @auth
+    Scenario: Edit stage - set 0 expiry
+        Given empty "archive"
+        Given empty "tasks"
+        Given empty "stages"
+        Given "desks"
+        """
+        [{"name": "Sports Desk"}]
+        """
+
+        When we post to "/stages"
+        """
+        {
+        "name": "update expiry",
+        "task_status": "todo",
+        "desk": "#desks._id#",
+        "content_expiry": 0
+        }
+        """
+
+        Given "archive"
+            """
+            [{"_id": "testid1", "guid": "testid1", "task": {"desk": "#desks._id#", "stage" :"#stages._id#"}}]
+            """
+
+        When we get "archive/testid1"
+        Then we get global content expiry
+
+        When we patch "/stages/#stages._id#"
+        """
+        {"content_expiry":20 }
+        """
+
+        When we get "archive/testid1"
+        Then we get content expiry 20
 
     @auth
     Scenario: Get tasks for stage


### PR DESCRIPTION
Tasks included:

[SD-1449] Use global content expiry as default on stages
[SD-1450] Remove desk level content expiry