### PR TITLE
refact(errors) - Wired the ingest errors to notifications and activity stream

### DIFF
--- a/superdesk/errors.py
+++ b/superdesk/errors.py
@@ -152,17 +152,18 @@ class InvalidStateTransitionError(SuperdeskApiError):
 
 
 class SuperdeskIngestError(SuperdeskError):
-    def __init__(self, code, exception, channel=None):
+    def __init__(self, code, exception, provider=None):
         super().__init__(code)
         self.system_exception = exception
-        self.channel = channel
+        self.provider_name = provider.get('name', 'Unknown provider') if provider else 'Unknown provider'
 
-        update_notifiers('error',
-                         'Error [%s] on ingest channel {{name}}: %s' % (code, exception),
-                         name=channel)
+        if provider.get('notifications', {}).get('on_error', True):
+            update_notifiers('error',
+                             'Error [%s] on ingest provider {{name}}: %s' % (code, exception),
+                             name=self.provider_name)
 
-        if channel:
-            logger.error("{}: {} on channel {}".format(self, exception, channel))
+        if provider:
+            logger.error("{}: {} on channel {}".format(self, exception, self.provider_name))
         else:
             logger.error("{}: {}".format(self, exception))
 
@@ -178,28 +179,28 @@ class ProviderError(SuperdeskIngestError):
     }
 
     @classmethod
-    def providerAddError(cls, exception, channel):
-        return ProviderError(2001, exception, channel)
+    def providerAddError(cls, exception, provider):
+        return ProviderError(2001, exception, provider)
 
     @classmethod
-    def expiredContentError(cls, exception, channel):
-        return ProviderError(2002, exception, channel)
+    def expiredContentError(cls, exception, provider):
+        return ProviderError(2002, exception, provider)
 
     @classmethod
-    def ruleError(cls, exception, channel):
-        return ProviderError(2003, exception, channel)
+    def ruleError(cls, exception, provider):
+        return ProviderError(2003, exception, provider)
 
     @classmethod
-    def ingestError(cls, exception, channel):
-        return ProviderError(2004, exception, channel)
+    def ingestError(cls, exception, provider):
+        return ProviderError(2004, exception, provider)
 
     @classmethod
-    def anpaError(cls, exception, channel):
-        return ProviderError(2005, exception, channel)
+    def anpaError(cls, exception, provider):
+        return ProviderError(2005, exception, provider)
 
     @classmethod
-    def providerFilterExpiredContentError(cls, exception, channel):
-        return ProviderError(2006, exception, channel)
+    def providerFilterExpiredContentError(cls, exception, provider):
+        return ProviderError(2006, exception, provider)
 
 
 class ParserError(SuperdeskIngestError):
@@ -213,13 +214,13 @@ class ParserError(SuperdeskIngestError):
     }
 
     @classmethod
-    def parseMessageError(cls, exception, channel):
-        return ParserError(1001, exception, channel)
+    def parseMessageError(cls, exception, provider):
+        return ParserError(1001, exception, provider)
 
     @classmethod
-    def parseFileError(cls, source, filename, exception, channel):
+    def parseFileError(cls, source, filename, exception, provider):
         logger.exception("Source Type: {} - File: {} could not be processed".format(source, filename))
-        return ParserError(1002, exception, channel)
+        return ParserError(1002, exception, provider)
 
     @classmethod
     def anpaParseFileError(cls, filename, exception):
@@ -227,16 +228,16 @@ class ParserError(SuperdeskIngestError):
         return ParserError(1003, exception)
 
     @classmethod
-    def newsmlOneParserError(cls, exception, channel):
-        return ParserError(1004, exception, channel)
+    def newsmlOneParserError(cls, exception, provider):
+        return ParserError(1004, exception, provider)
 
     @classmethod
-    def newsmlTwoParserError(cls, exception, channel):
-        return ParserError(1005, exception, channel)
+    def newsmlTwoParserError(cls, exception, provider):
+        return ParserError(1005, exception, provider)
 
     @classmethod
-    def nitfParserError(cls, exception, channel):
-        return ParserError(1006, exception, channel)
+    def nitfParserError(cls, exception, provider):
+        return ParserError(1006, exception, provider)
 
 
 class IngestFileError(SuperdeskIngestError):
@@ -246,12 +247,12 @@ class IngestFileError(SuperdeskIngestError):
     }
 
     @classmethod
-    def folderCreateError(cls, exception, channel):
-        return IngestFileError(3001, exception, channel)
+    def folderCreateError(cls, exception, provider):
+        return IngestFileError(3001, exception, provider)
 
     @classmethod
-    def fileMoveError(cls, exception, channel):
-        return IngestFileError(3002, exception, channel)
+    def fileMoveError(cls, exception, provider):
+        return IngestFileError(3002, exception, provider)
 
 
 class IngestApiError(SuperdeskIngestError):
@@ -266,28 +267,28 @@ class IngestApiError(SuperdeskIngestError):
     }
 
     @classmethod
-    def apiTimeoutError(cls, exception, channel):
-        return IngestApiError(4001, exception, channel)
+    def apiTimeoutError(cls, exception, provider):
+        return IngestApiError(4001, exception, provider)
 
     @classmethod
-    def apiRedirectError(cls, exception, channel):
-        return IngestApiError(4002, exception, channel)
+    def apiRedirectError(cls, exception, provider):
+        return IngestApiError(4002, exception, provider)
 
     @classmethod
-    def apiRequestError(cls, exception, channel):
-        return IngestApiError(4003, exception, channel)
+    def apiRequestError(cls, exception, provider):
+        return IngestApiError(4003, exception, provider)
 
     @classmethod
-    def apiUnicodeError(cls, exception, channel):
-        return IngestApiError(4004, exception, channel)
+    def apiUnicodeError(cls, exception, provider):
+        return IngestApiError(4004, exception, provider)
 
     @classmethod
-    def apiParseError(cls, exception, channel):
-        return IngestApiError(4005, exception, channel)
+    def apiParseError(cls, exception, provider):
+        return IngestApiError(4005, exception, provider)
 
     @classmethod
-    def apiNotFoundError(cls, exception, channel):
-        return IngestApiError(4006, exception, channel)
+    def apiNotFoundError(cls, exception, provider):
+        return IngestApiError(4006, exception, provider)
 
 
 class IngestFtpError(SuperdeskIngestError):
@@ -297,11 +298,12 @@ class IngestFtpError(SuperdeskIngestError):
     }
 
     @classmethod
-    def ftpError(cls, exception, channel):
-        return IngestFtpError(5000, exception, channel)
+    def ftpError(cls, exception, provider):
+        return IngestFtpError(5000, exception, provider)
 
     @classmethod
-    def ftpUnknownParserError(cls, exception, channel, filename):
-        logger.exception("Provider: {} - File: {} unknown file format. "
-                         "Parser couldn't be found.".format(channel, filename))
-        return IngestFtpError(5001, exception, channel)
+    def ftpUnknownParserError(cls, exception, provider, filename):
+        if provider:
+            logger.exception("Provider: {} - File: {} unknown file format. "
+                             "Parser couldn't be found.".format(provider.get('name', 'Unknown provider'), filename))
+        return IngestFtpError(5001, exception, provider)

--- a/superdesk/errors_test.py
+++ b/superdesk/errors_test.py
@@ -54,7 +54,7 @@ class ErrorsTestCase(TestCase):
     def test_raise_apiRequestError(self):
         with assert_raises(IngestApiError) as error_context:
             ex = Exception("Testing apiRequestError")
-            raise IngestApiError.apiRequestError(ex, self.provider.get('name'))
+            raise IngestApiError.apiRequestError(ex, self.provider)
         exception = error_context.exception
         self.assertTrue(exception.code == 4003)
         self.assertTrue(exception.message == "API ingest has request error")
@@ -68,7 +68,7 @@ class ErrorsTestCase(TestCase):
     def test_raise_apiTimeoutError(self):
         with assert_raises(IngestApiError) as error_context:
             ex = Exception("Testing apiTimeoutError")
-            raise IngestApiError.apiTimeoutError(ex, self.provider.get('name'))
+            raise IngestApiError.apiTimeoutError(ex, self.provider)
         exception = error_context.exception
         self.assertTrue(exception.code == 4001)
         self.assertTrue(exception.message == "API ingest connection has timed out.")
@@ -82,7 +82,7 @@ class ErrorsTestCase(TestCase):
     def test_raise_apiRedirectError(self):
         with assert_raises(IngestApiError) as error_context:
             ex = Exception("Testing apiRedirectError")
-            raise IngestApiError.apiRedirectError(ex, self.provider.get('name'))
+            raise IngestApiError.apiRedirectError(ex, self.provider)
         exception = error_context.exception
         self.assertTrue(exception.code == 4002)
         self.assertTrue(exception.message == "API ingest has too many redirects")
@@ -96,7 +96,7 @@ class ErrorsTestCase(TestCase):
     def test_raise_apiUnicodeError(self):
         with assert_raises(IngestApiError) as error_context:
             ex = Exception("Testing apiUnicodeError")
-            raise IngestApiError.apiUnicodeError(ex, self.provider.get('name'))
+            raise IngestApiError.apiUnicodeError(ex, self.provider)
         exception = error_context.exception
         self.assertTrue(exception.code == 4004)
         self.assertTrue(exception.message == "API ingest Unicode Encode Error")
@@ -110,7 +110,7 @@ class ErrorsTestCase(TestCase):
     def test_raise_apiParseError(self):
         with assert_raises(IngestApiError) as error_context:
             ex = Exception("Testing apiParseError")
-            raise IngestApiError.apiParseError(ex, self.provider.get('name'))
+            raise IngestApiError.apiParseError(ex, self.provider)
         exception = error_context.exception
         self.assertTrue(exception.code == 4005)
         self.assertTrue(exception.message == "API ingest xml parse error")
@@ -124,7 +124,7 @@ class ErrorsTestCase(TestCase):
     def test_raise_apiNotFoundError(self):
         with assert_raises(IngestApiError) as error_context:
             ex = Exception("Testing apiNotFoundError")
-            raise IngestApiError.apiNotFoundError(ex, self.provider.get('name'))
+            raise IngestApiError.apiNotFoundError(ex, self.provider)
         exception = error_context.exception
         self.assertTrue(exception.code == 4006)
         self.assertTrue(exception.message == "API service not found(404) error")
@@ -138,7 +138,7 @@ class ErrorsTestCase(TestCase):
     def test_raise_folderCreateError(self):
         with assert_raises(IngestFileError) as error_context:
             ex = Exception("Testing folderCreateError")
-            raise IngestFileError.folderCreateError(ex, self.provider.get('name'))
+            raise IngestFileError.folderCreateError(ex, self.provider)
         exception = error_context.exception
         self.assertTrue(exception.code == 3001)
         self.assertTrue(exception.message == "Destination folder could not be created")
@@ -152,7 +152,7 @@ class ErrorsTestCase(TestCase):
     def test_raise_fileMoveError(self):
         with assert_raises(IngestFileError) as error_context:
             ex = Exception("Testing fileMoveError")
-            raise IngestFileError.fileMoveError(ex, self.provider.get('name'))
+            raise IngestFileError.fileMoveError(ex, self.provider)
         exception = error_context.exception
         self.assertTrue(exception.code == 3002)
         self.assertTrue(exception.message == "Ingest file could not be copied")
@@ -166,7 +166,7 @@ class ErrorsTestCase(TestCase):
     def test_raise_parseMessageError(self):
         with assert_raises(ParserError) as error_context:
             ex = Exception("Testing parseMessageError")
-            raise ParserError.parseMessageError(ex, self.provider.get('name'))
+            raise ParserError.parseMessageError(ex, self.provider)
         exception = error_context.exception
         self.assertTrue(exception.code == 1001)
         self.assertTrue(exception.message == "Message could not be parsed")
@@ -183,7 +183,7 @@ class ErrorsTestCase(TestCase):
                 ex = Exception("Testing parseFileError")
                 raise ex
             except Exception:
-                raise ParserError.parseFileError('afp', 'test.txt', ex, self.provider.get('name'))
+                raise ParserError.parseFileError('afp', 'test.txt', ex, self.provider)
         exception = error_context.exception
         self.assertTrue(exception.code == 1002)
         self.assertTrue(exception.message == "Ingest file could not be parsed")
@@ -202,7 +202,7 @@ class ErrorsTestCase(TestCase):
                 ex = Exception("Testing newsmlOneParserError")
                 raise ex
             except Exception:
-                raise ParserError.newsmlOneParserError(ex, self.provider.get('name'))
+                raise ParserError.newsmlOneParserError(ex, self.provider)
         exception = error_context.exception
         self.assertTrue(exception.code == 1004)
         self.assertTrue(exception.message == "NewsML1 input could not be processed")
@@ -219,7 +219,7 @@ class ErrorsTestCase(TestCase):
                 ex = Exception("Testing newsmlTwoParserError")
                 raise ex
             except Exception:
-                raise ParserError.newsmlTwoParserError(ex, self.provider.get('name'))
+                raise ParserError.newsmlTwoParserError(ex, self.provider)
         exception = error_context.exception
         self.assertTrue(exception.code == 1005)
         self.assertTrue(exception.message == "NewsML2 input could not be processed")
@@ -236,7 +236,7 @@ class ErrorsTestCase(TestCase):
                 ex = Exception("Testing nitfParserError")
                 raise ex
             except Exception:
-                raise ParserError.nitfParserError(ex, self.provider.get('name'))
+                raise ParserError.nitfParserError(ex, self.provider)
         exception = error_context.exception
         self.assertTrue(exception.code == 1006)
         self.assertTrue(exception.message == "NITF input could not be processed")
@@ -253,7 +253,7 @@ class ErrorsTestCase(TestCase):
                 ex = Exception("Testing folderCreateError")
                 raise ex
             except Exception:
-                raise IngestFileError.folderCreateError(ex, self.provider.get('name'))
+                raise IngestFileError.folderCreateError(ex, self.provider)
         exception = error_context.exception
         self.assertTrue(exception.code == 3001)
         self.assertTrue(exception.message == "Destination folder could not be created")
@@ -270,7 +270,7 @@ class ErrorsTestCase(TestCase):
                 ex = Exception("Testing fileMoveError")
                 raise ex
             except Exception:
-                raise IngestFileError.fileMoveError(ex, self.provider.get('name'))
+                raise IngestFileError.fileMoveError(ex, self.provider)
         exception = error_context.exception
         self.assertTrue(exception.code == 3002)
         self.assertTrue(exception.message == "Ingest file could not be copied")
@@ -287,7 +287,7 @@ class ErrorsTestCase(TestCase):
                 ex = Exception("Testing providerAddError")
                 raise ex
             except Exception:
-                raise ProviderError.providerAddError(ex, self.provider.get('name'))
+                raise ProviderError.providerAddError(ex, self.provider)
         exception = error_context.exception
         self.assertTrue(exception.code == 2001)
         self.assertTrue(exception.message == "Provider could not be saved")
@@ -304,7 +304,7 @@ class ErrorsTestCase(TestCase):
                 ex = Exception("Testing expiredContentError")
                 raise ex
             except Exception:
-                raise ProviderError.expiredContentError(ex, self.provider.get('name'))
+                raise ProviderError.expiredContentError(ex, self.provider)
         exception = error_context.exception
         self.assertTrue(exception.code == 2002)
         self.assertTrue(exception.message == "Expired content could not be removed")
@@ -321,7 +321,7 @@ class ErrorsTestCase(TestCase):
                 ex = Exception("Testing ruleError")
                 raise ex
             except Exception:
-                raise ProviderError.ruleError(ex, self.provider.get('name'))
+                raise ProviderError.ruleError(ex, self.provider)
         exception = error_context.exception
         self.assertTrue(exception.code == 2003)
         self.assertTrue(exception.message == "Rule could not be applied")
@@ -338,17 +338,17 @@ class ErrorsTestCase(TestCase):
                 ex = Exception("Testing ingestError")
                 raise ex
             except Exception:
-                raise ProviderError.ingestError(ex, 'afp')
+                raise ProviderError.ingestError(ex, self.provider)
         exception = error_context.exception
         self.assertTrue(exception.code == 2004)
         self.assertTrue(exception.message == "Ingest error")
-        self.assertTrue(exception.channel == "afp")
+        self.assertTrue(exception.provider_name == "TestProvider")
         self.assertIsNotNone(exception.system_exception)
         self.assertEquals(exception.system_exception.args[0], "Testing ingestError")
         self.assertEqual(len(self.mock_logger_handler.messages['error']), 1)
         self.assertEqual(self.mock_logger_handler.messages['error'][0],
                          "ProviderError Error 2004 - Ingest error: "
-                         "Testing ingestError on channel afp")
+                         "Testing ingestError on channel TestProvider")
 
     def test_raise_anpaError(self):
         with assert_raises(ProviderError) as error_context:
@@ -356,7 +356,7 @@ class ErrorsTestCase(TestCase):
                 ex = Exception("Testing anpaError")
                 raise ex
             except Exception:
-                raise ProviderError.anpaError(ex, self.provider.get('name'))
+                raise ProviderError.anpaError(ex, self.provider)
         exception = error_context.exception
         self.assertTrue(exception.code == 2005)
         self.assertTrue(exception.message == "Anpa category error")
@@ -373,7 +373,7 @@ class ErrorsTestCase(TestCase):
                 ex = Exception("Testing providerFilterExpiredContentError")
                 raise ex
             except Exception:
-                raise ProviderError.providerFilterExpiredContentError(ex, self.provider.get('name'))
+                raise ProviderError.providerFilterExpiredContentError(ex, self.provider)
         exception = error_context.exception
         self.assertTrue(exception.code == 2006)
         self.assertTrue(exception.message == "Expired content could not be filtered")
@@ -390,7 +390,7 @@ class ErrorsTestCase(TestCase):
                 ex = Exception("Testing ftpError")
                 raise ex
             except Exception:
-                raise IngestFtpError.ftpError(ex, self.provider.get('name'))
+                raise IngestFtpError.ftpError(ex, self.provider)
         exception = error_context.exception
         self.assertTrue(exception.code == 5000)
         self.assertTrue(exception.message == "FTP ingest error")
@@ -407,7 +407,7 @@ class ErrorsTestCase(TestCase):
                 ex = Exception("Testing ftpUnknownParserError")
                 raise ex
             except Exception:
-                raise IngestFtpError.ftpUnknownParserError(ex, self.provider.get('name'), 'test.xml')
+                raise IngestFtpError.ftpUnknownParserError(ex, self.provider, 'test.xml')
         exception = error_context.exception
         self.assertTrue(exception.code == 5001)
         self.assertTrue(exception.message == "FTP parser could not be found")

--- a/superdesk/io/__init__.py
+++ b/superdesk/io/__init__.py
@@ -63,7 +63,7 @@ class ParserRegistry(type):
 class Parser(metaclass=ParserRegistry):
     """Base Parser class for all types of Parsers like News ML 1.2, News ML G2, NITF, etc."""
 
-    def parse_message(self, xml):
+    def parse_message(self, xml, provider):
         """Parse the ingest XML and extracts the relevant elements/attributes values from the XML."""
         raise NotImplementedError()
 

--- a/superdesk/io/aap.py
+++ b/superdesk/io/aap.py
@@ -69,12 +69,12 @@ class AAPIngestService(FileIngestService):
             except etreeParserError as ex:
                 logger.exception("Ingest Type: AAP - File: {0} could not be processed".format(filename))
                 self.move_file(self.path, filename, provider=provider, success=False)
-                raise ParserError.nitfParserError(ex, provider.get('name'))
+                raise ParserError.nitfParserError(ex, provider)
             except ParserError as ex:
                 self.move_file(self.path, filename, provider=provider, success=False)
             except Exception as ex:
                 self.move_file(self.path, filename, provider=provider, success=False)
-                raise ProviderError.ingestError(ex, provider.get('name'))
+                raise ProviderError.ingestError(ex, provider)
 
         push_notification('ingest:update')
 
@@ -94,6 +94,6 @@ class AAPIngestService(FileIngestService):
             return [item]
         except Exception as ex:
             self.move_file(self.path, filename, provider=provider, success=False)
-            raise ParserError.parseFileError('AAP', filename, ex, provider.get('name'))
+            raise ParserError.parseFileError('AAP', filename, ex, provider)
 
 register_provider(PROVIDER, AAPIngestService())

--- a/superdesk/io/afp.py
+++ b/superdesk/io/afp.py
@@ -57,12 +57,12 @@ class AFPIngestService(FileIngestService):
             except etreeParserError as ex:
                 logger.exception("Ingest Type: AFP - File: {0} could not be processed".format(filename), ex)
                 self.move_file(self.path, filename, provider=provider, success=False)
-                raise ParserError.newsmlOneParserError(ex, provider.get('name'))
+                raise ParserError.newsmlOneParserError(ex, provider)
             except ParserError as ex:
                 self.move_file(self.path, filename, provider=provider, success=False)
             except Exception as ex:
                 self.move_file(self.path, filename, provider=provider, success=False)
-                raise ProviderError.ingestError(ex, provider.get('name'))
+                raise ProviderError.ingestError(ex, provider)
 
         push_notification('ingest:update')
 

--- a/superdesk/io/afp.py
+++ b/superdesk/io/afp.py
@@ -17,9 +17,10 @@ from .newsml_1_2 import NewsMLOneParser
 from superdesk.io.file_ingest_service import FileIngestService
 from superdesk.utils import get_sorted_files, FileSortAttributes
 from ..utc import utc
-from ..etree import etree
+from ..etree import etree, ParseError as etreeParserError
 from superdesk.notification import push_notification
 from superdesk.io import register_provider
+from superdesk.errors import ParserError, ProviderError
 
 
 logger = logging.getLogger(__name__)
@@ -46,16 +47,22 @@ class AFPIngestService(FileIngestService):
                     last_updated = datetime.fromtimestamp(stat.st_mtime, tz=utc)
                     if self.is_latest_content(last_updated, provider.get('last_updated')):
                         with open(os.path.join(self.path, filename), 'r') as f:
-                            item = self.parser.parse_message(etree.fromstring(f.read()))
+                            item = self.parser.parse_message(etree.fromstring(f.read()), provider)
 
                             self.add_timestamps(item)
-                            self.move_file(self.path, filename, success=True)
+                            self.move_file(self.path, filename, provider=provider, success=True)
                             yield [item]
                     else:
-                        self.move_file(self.path, filename, success=True)
+                        self.move_file(self.path, filename, provider=provider, success=True)
+            except etreeParserError as ex:
+                logger.exception("Ingest Type: AFP - File: {0} could not be processed".format(filename), ex)
+                self.move_file(self.path, filename, provider=provider, success=False)
+                raise ParserError.newsmlOneParserError(ex, provider.get('name'))
+            except ParserError as ex:
+                self.move_file(self.path, filename, provider=provider, success=False)
             except Exception as ex:
-                logger.exception("Ingest Type: AFP - File: {} could not be processed".format(filename), ex)
-                self.move_file(self.path, filename, success=False)
+                self.move_file(self.path, filename, provider=provider, success=False)
+                raise ProviderError.ingestError(ex, provider.get('name'))
 
         push_notification('ingest:update')
 

--- a/superdesk/io/afp_tests.py
+++ b/superdesk/io/afp_tests.py
@@ -19,8 +19,9 @@ class TestCase(unittest.TestCase):
     def setUp(self):
         dirname = os.path.dirname(os.path.realpath(__file__))
         fixture = os.path.join(dirname, 'fixtures', 'afp.xml')
+        provider = {'name': 'Test'}
         with open(fixture) as f:
-            self.item = NewsMLOneParser().parse_message(etree.fromstring(f.read()))
+            self.item = NewsMLOneParser().parse_message(etree.fromstring(f.read()), provider)
 
     def test_headline(self):
         self.assertEquals(self.item.get('headline'), 'Sweden court accepts receivership for Saab carmaker')

--- a/superdesk/io/commands/add_provider.py
+++ b/superdesk/io/commands/add_provider.py
@@ -21,16 +21,17 @@ class AddProvider(superdesk.Command):
     }
 
     def run(self, provider=None):
-        try:
             if provider:
-                data = superdesk.json.loads(provider)
-                data.setdefault('name', data['type'])
-                data.setdefault('source', data['type'])
-                data.setdefault('days_to_keep', DAYS_TO_KEEP)
-                db = superdesk.get_db()
-                db['ingest_providers'].save(data)
-                return data
-        except Exception as ex:
-            raise ProviderError.providerAddError(ex)
+                try:
+                    data = {}
+                    data = superdesk.json.loads(provider)
+                    data.setdefault('name', data['type'])
+                    data.setdefault('source', data['type'])
+                    data.setdefault('days_to_keep', DAYS_TO_KEEP)
+                    db = superdesk.get_db()
+                    db['ingest_providers'].save(data)
+                    return data
+                except Exception as ex:
+                    raise ProviderError.providerAddError(ex, data.get('name', ''))
 
 superdesk.command('ingest:provider', AddProvider())

--- a/superdesk/io/commands/add_provider.py
+++ b/superdesk/io/commands/add_provider.py
@@ -32,6 +32,6 @@ class AddProvider(superdesk.Command):
                     db['ingest_providers'].save(data)
                     return data
                 except Exception as ex:
-                    raise ProviderError.providerAddError(ex, data.get('name', ''))
+                    raise ProviderError.providerAddError(ex, data)
 
 superdesk.command('ingest:provider', AddProvider())

--- a/superdesk/io/commands/remove_expired_content.py
+++ b/superdesk/io/commands/remove_expired_content.py
@@ -36,7 +36,7 @@ class RemoveExpiredContent(superdesk.Command):
                     remove_expired_data(provider)
                 except (Exception) as err:
                     logger.exception(err)
-                    raise ProviderError.expiredContentError(err)
+                    raise ProviderError.expiredContentError(err, provider.get('name'))
                 finally:
                     push_notification('ingest:cleaned')
 

--- a/superdesk/io/commands/remove_expired_content.py
+++ b/superdesk/io/commands/remove_expired_content.py
@@ -36,7 +36,7 @@ class RemoveExpiredContent(superdesk.Command):
                     remove_expired_data(provider)
                 except (Exception) as err:
                     logger.exception(err)
-                    raise ProviderError.expiredContentError(err, provider.get('name'))
+                    raise ProviderError.expiredContentError(err, provider)
                 finally:
                     push_notification('ingest:cleaned')
 

--- a/superdesk/io/commands/update_ingest.py
+++ b/superdesk/io/commands/update_ingest.py
@@ -83,7 +83,7 @@ def filter_expired_items(provider, items):
         expiration_date = utcnow() - timedelta(days=days_to_keep_content)
         return [item for item in items if item.get('versioncreated', utcnow()) > expiration_date]
     except Exception as ex:
-        raise ProviderError.providerFilterExpiredContentError(ex)
+        raise ProviderError.providerFilterExpiredContentError(ex, provider.get('name'))
 
 
 class UpdateIngest(superdesk.Command):
@@ -123,7 +123,7 @@ def update_provider(provider, rule_set=None):
     push_notification('ingest:update')
 
 
-def process_anpa_category(item):
+def process_anpa_category(item, provider):
     try:
         anpa_categories = superdesk.get_resource_service('vocabularies').find_one(req=None, _id='categories')
         if anpa_categories:
@@ -133,7 +133,7 @@ def process_anpa_category(item):
                     item['anpa-category'] = {'qcode': item['anpa-category']['qcode'], 'name': anpa_category['name']}
                     break
     except Exception as ex:
-        raise ProviderError.anpaError(ex)
+        raise ProviderError.anpaError(ex, provider.get('name'))
 
 
 def apply_rule_set(item, provider, rule_set=None):
@@ -159,7 +159,7 @@ def apply_rule_set(item, provider, rule_set=None):
 
         return item
     except Exception as ex:
-        raise ProviderError.ruleError(ex)
+        raise ProviderError.ruleError(ex, provider.get('name'))
 
 
 def ingest_items(items, provider, rule_set=None):
@@ -189,7 +189,7 @@ def ingest_item(item, provider, rule_set=None):
         set_default_state(item, STATE_INGESTED)
 
         if 'anpa-category' in item:
-            process_anpa_category(item)
+            process_anpa_category(item, provider)
 
         apply_rule_set(item, provider, rule_set)
 

--- a/superdesk/io/commands/update_ingest.py
+++ b/superdesk/io/commands/update_ingest.py
@@ -83,7 +83,7 @@ def filter_expired_items(provider, items):
         expiration_date = utcnow() - timedelta(days=days_to_keep_content)
         return [item for item in items if item.get('versioncreated', utcnow()) > expiration_date]
     except Exception as ex:
-        raise ProviderError.providerFilterExpiredContentError(ex, provider.get('name'))
+        raise ProviderError.providerFilterExpiredContentError(ex, provider)
 
 
 class UpdateIngest(superdesk.Command):
@@ -133,7 +133,7 @@ def process_anpa_category(item, provider):
                     item['anpa-category'] = {'qcode': item['anpa-category']['qcode'], 'name': anpa_category['name']}
                     break
     except Exception as ex:
-        raise ProviderError.anpaError(ex, provider.get('name'))
+        raise ProviderError.anpaError(ex, provider)
 
 
 def apply_rule_set(item, provider, rule_set=None):
@@ -159,7 +159,7 @@ def apply_rule_set(item, provider, rule_set=None):
 
         return item
     except Exception as ex:
-        raise ProviderError.ruleError(ex, provider.get('name'))
+        raise ProviderError.ruleError(ex, provider)
 
 
 def ingest_items(items, provider, rule_set=None):
@@ -218,7 +218,7 @@ def ingest_item(item, provider, rule_set=None):
     except ProviderError:
         raise
     except Exception as ex:
-        raise ProviderError.ingestError(ex, provider.get('name'))
+        raise ProviderError.ingestError(ex, provider)
 
 
 def update_renditions(item, href):

--- a/superdesk/io/file_ingest_service.py
+++ b/superdesk/io/file_ingest_service.py
@@ -18,7 +18,7 @@ from superdesk.errors import IngestFileError
 
 class FileIngestService(IngestService):
 
-    def move_file(self, filepath, filename, success=True):
+    def move_file(self, filepath, filename, provider, success=True):
         """
         Move the files from the current directory to the _Processed directory in successful
         else _Error if unsuccessful. Creates _Processed and _Error directory within current directory
@@ -30,7 +30,7 @@ class FileIngestService(IngestService):
             if not os.path.exists(os.path.join(filepath, "_ERROR/")):
                 os.makedirs(os.path.join(filepath, "_ERROR/"))
         except Exception as ex:
-            raise IngestFileError.folderCreateError(ex)
+            raise IngestFileError.folderCreateError(ex, provider.get('name'))
 
         try:
             if success:
@@ -38,7 +38,7 @@ class FileIngestService(IngestService):
             else:
                 shutil.copy2(os.path.join(filepath, filename), os.path.join(filepath, "_ERROR/"))
         except Exception as ex:
-            raise IngestFileError.fileMoveError(ex)
+            raise IngestFileError.fileMoveError(ex, provider.get('name'))
         finally:
             os.remove(os.path.join(filepath, filename))
 

--- a/superdesk/io/file_ingest_service.py
+++ b/superdesk/io/file_ingest_service.py
@@ -30,7 +30,7 @@ class FileIngestService(IngestService):
             if not os.path.exists(os.path.join(filepath, "_ERROR/")):
                 os.makedirs(os.path.join(filepath, "_ERROR/"))
         except Exception as ex:
-            raise IngestFileError.folderCreateError(ex, provider.get('name'))
+            raise IngestFileError.folderCreateError(ex, provider)
 
         try:
             if success:
@@ -38,7 +38,7 @@ class FileIngestService(IngestService):
             else:
                 shutil.copy2(os.path.join(filepath, filename), os.path.join(filepath, "_ERROR/"))
         except Exception as ex:
-            raise IngestFileError.fileMoveError(ex, provider.get('name'))
+            raise IngestFileError.fileMoveError(ex, provider)
         finally:
             os.remove(os.path.join(filepath, filename))
 

--- a/superdesk/io/ftp.py
+++ b/superdesk/io/ftp.py
@@ -72,7 +72,7 @@ class FTPService(IngestService):
                     dest = '%s/%s' % (config['dest_path'], filename)
 
                     try:
-                        with open(dest, 'wb') as f:
+                        with open(dest, 'xb') as f:
                             ftp.retrbinary('RETR %s' % filename, f.write)
                     except FileExistsError:
                         continue

--- a/superdesk/io/ftp.py
+++ b/superdesk/io/ftp.py
@@ -77,13 +77,12 @@ class FTPService(IngestService):
                     parser = get_xml_parser(xml)
                     if not parser:
                         raise IngestFtpError.ftpUnknownParserError(Exception('Parser not found'),
-                                                                   provider.get('name'),
-                                                                   filename)
+                                                                   provider, filename)
                     items.append(parser.parse_message(xml, provider))
             return items
         except IngestFtpError:
             raise
         except Exception as ex:
-            raise IngestFtpError.ftpError(ex, provider.get('name'))
+            raise IngestFtpError.ftpError(ex, provider)
 
 register_provider('ftp', FTPService())

--- a/superdesk/io/ftp.py
+++ b/superdesk/io/ftp.py
@@ -16,6 +16,7 @@ from superdesk.utc import utc
 from superdesk.etree import etree
 from superdesk.io import get_xml_parser, register_provider
 from .ingest_service import IngestService
+from superdesk.errors import IngestFtpError
 
 try:
     from urllib.parse import urlparse
@@ -50,30 +51,39 @@ class FTPService(IngestService):
             config['dest_path'] = tempfile.mkdtemp(prefix='superdesk_ingest_')
 
         items = []
-        with ftplib.FTP(config.get('host')) as ftp:
-            ftp.login(config.get('username'), config.get('password'))
-            ftp.cwd(config.get('path', ''))
+        try:
+            with ftplib.FTP(config.get('host')) as ftp:
+                ftp.login(config.get('username'), config.get('password'))
+                ftp.cwd(config.get('path', ''))
 
-            for filename, facts in ftp.mlsd():
-                if not filename.endswith(self.FILE_SUFFIX):
-                    continue
-
-                if last_updated:
-                    item_last_updated = datetime.strptime(facts['modify'], self.DATE_FORMAT).replace(tzinfo=utc)
-                    if item_last_updated < last_updated:
+                for filename, facts in ftp.mlsd():
+                    if not filename.endswith(self.FILE_SUFFIX):
                         continue
 
-                dest = '%s/%s' % (config['dest_path'], filename)
+                    if last_updated:
+                        item_last_updated = datetime.strptime(facts['modify'], self.DATE_FORMAT).replace(tzinfo=utc)
+                        if item_last_updated < last_updated:
+                            continue
 
-                try:
-                    with open(dest, 'xb') as f:
-                        ftp.retrbinary('RETR %s' % filename, f.write)
-                except FileExistsError:
-                    continue
+                    dest = '%s/%s' % (config['dest_path'], filename)
 
-                xml = etree.parse(dest).getroot()
-                items.append(get_xml_parser(xml).parse_message(xml))
-        return items
+                    try:
+                        with open(dest, 'xb') as f:
+                            ftp.retrbinary('RETR %s' % filename, f.write)
+                    except FileExistsError:
+                        continue
 
+                    xml = etree.parse(dest).getroot()
+                    parser = get_xml_parser(xml)
+                    if not parser:
+                        raise IngestFtpError.ftpUnknownParserError(Exception('Parser not found'),
+                                                                   provider.get('name'),
+                                                                   filename)
+                    items.append(parser.parse_message(xml, provider))
+            return items
+        except IngestFtpError:
+            raise
+        except Exception as ex:
+            raise IngestFtpError.ftpError(ex, provider.get('name'))
 
 register_provider('ftp', FTPService())

--- a/superdesk/io/io_tests.py
+++ b/superdesk/io/io_tests.py
@@ -53,7 +53,8 @@ class ItemTest(unittest.TestCase):
 
     def setUpFixture(self, filename):
         self.tree = get_etree(filename)
-        self.item = get_xml_parser(self.tree).parse_message(self.tree)[0]
+        provider = {'name': 'Test'}
+        self.item = get_xml_parser(self.tree).parse_message(self.tree, provider)[0]
 
 
 class ParserTest(ItemTest):

--- a/superdesk/io/newsml_1_2.py
+++ b/superdesk/io/newsml_1_2.py
@@ -22,7 +22,7 @@ class NewsMLOneParser(Parser):
     def can_parse(self, xml):
         return xml.tag == 'NewsML' and xml.get('Version', '') == '1.2'
 
-    def parse_message(self, tree):
+    def parse_message(self, tree, provider):
         """Parse NewsMessage."""
         item = {}
         try:
@@ -79,7 +79,7 @@ class NewsMLOneParser(Parser):
 
             return self.populate_fields(item)
         except Exception as ex:
-            raise ParserError.newsmlOneParserError(ex)
+            raise ParserError.newsmlOneParserError(ex, provider.get('name'))
 
     def parse_elements(self, tree):
         items = {}

--- a/superdesk/io/newsml_1_2.py
+++ b/superdesk/io/newsml_1_2.py
@@ -79,7 +79,7 @@ class NewsMLOneParser(Parser):
 
             return self.populate_fields(item)
         except Exception as ex:
-            raise ParserError.newsmlOneParserError(ex, provider.get('name'))
+            raise ParserError.newsmlOneParserError(ex, provider)
 
     def parse_elements(self, tree):
         items = {}

--- a/superdesk/io/newsml_2_0.py
+++ b/superdesk/io/newsml_2_0.py
@@ -29,7 +29,7 @@ class NewsMLTwoParser(Parser):
     def can_parse(self, xml):
         return xml.tag.endswith('newsMessage')
 
-    def parse_message(self, tree):
+    def parse_message(self, tree, provider):
         """Parse NewsMessage."""
         items = []
         try:
@@ -40,7 +40,7 @@ class NewsMLTwoParser(Parser):
                     items.append(item)
             return items
         except Exception as ex:
-            raise ParserError.newsmlTwoParserError(ex)
+            raise ParserError.newsmlTwoParserError(ex, provider.get('name'))
 
     def parse_item(self, tree):
         """Parse given xml"""

--- a/superdesk/io/newsml_2_0.py
+++ b/superdesk/io/newsml_2_0.py
@@ -40,7 +40,7 @@ class NewsMLTwoParser(Parser):
                     items.append(item)
             return items
         except Exception as ex:
-            raise ParserError.newsmlTwoParserError(ex, provider.get('name'))
+            raise ParserError.newsmlTwoParserError(ex, provider)
 
     def parse_item(self, tree):
         """Parse given xml"""

--- a/superdesk/io/nitf.py
+++ b/superdesk/io/nitf.py
@@ -106,7 +106,7 @@ class NITFParser(Parser):
     def can_parse(self, xml):
         return xml.tag == 'nitf'
 
-    def parse_message(self, tree):
+    def parse_message(self, tree, provider):
         item = {}
         try:
             docdata = tree.find('head/docdata')
@@ -139,4 +139,4 @@ class NITFParser(Parser):
             item.setdefault('word_count', get_word_count(item['body_html']))
             return item
         except Exception as ex:
-            raise ParserError.nitfParserError(ex)
+            raise ParserError.nitfParserError(ex, provider.get('name'))

--- a/superdesk/io/nitf.py
+++ b/superdesk/io/nitf.py
@@ -139,4 +139,4 @@ class NITFParser(Parser):
             item.setdefault('word_count', get_word_count(item['body_html']))
             return item
         except Exception as ex:
-            raise ParserError.nitfParserError(ex, provider.get('name'))
+            raise ParserError.nitfParserError(ex, provider)

--- a/superdesk/io/nitf_tests.py
+++ b/superdesk/io/nitf_tests.py
@@ -20,9 +20,10 @@ class NITFTestCase(unittest.TestCase):
     def setUp(self):
         dirname = os.path.dirname(os.path.realpath(__file__))
         fixture = os.path.join(dirname, 'fixtures', self.filename)
+        provider = {'name': 'Test'}
         with open(fixture) as f:
             self.nitf = f.read()
-            self.item = NITFParser().parse_message(etree.fromstring(self.nitf))
+            self.item = NITFParser().parse_message(etree.fromstring(self.nitf), provider)
 
 
 class AAPTestCase(NITFTestCase):

--- a/superdesk/io/reuters.py
+++ b/superdesk/io/reuters.py
@@ -84,7 +84,7 @@ class ReutersIngestService(IngestService):
         """Parse item message and return given items."""
         payload = {'id': guid}
         tree = self.get_tree('item', payload)
-        items = self.parser.parse_message(tree)
+        items = self.parser.parse_message(tree, self.provider)
         return items
 
     def get_ids(self, channel, last_updated, updated):
@@ -116,19 +116,19 @@ class ReutersIngestService(IngestService):
             response = requests.get(url, params=payload, timeout=21.0)
         except requests.exceptions.Timeout as ex:
             # Maybe set up for a retry, or continue in a retry loop
-            raise IngestApiError.apiTimeoutError(ex)
+            raise IngestApiError.apiTimeoutError(ex, self.provider)
         except requests.exceptions.TooManyRedirects as ex:
             # Tell the user their URL was bad and try a different one
-            raise IngestApiError.apiRedirectError(ex)
+            raise IngestApiError.apiRedirectError(ex, self.provider)
         except requests.exceptions.RequestException as ex:
             # catastrophic error. bail.
-            raise IngestApiError.apiRequestError(ex)
+            raise IngestApiError.apiRequestError(ex, self.provider)
         except Exception as error:
             traceback.print_exc()
-            raise IngestApiError(error)
+            raise IngestApiError(error, self.provider)
 
         if response.status_code == 404:
-            raise LookupError('Not found %s' % payload)
+            raise IngestApiError.apiNotFoundError(LookupError('Not found %s' % payload), self.provider)
 
         try:
             # workaround for httmock lib
@@ -136,13 +136,13 @@ class ReutersIngestService(IngestService):
             return etree.fromstring(response.content)
         except UnicodeEncodeError as error:
             traceback.print_exc()
-            raise IngestApiError.apiUnicodeError(error)
+            raise IngestApiError.apiUnicodeError(error, self.provider)
         except ParseError as error:
             traceback.print_exc()
-            raise IngestApiError.apiParseError(error)
+            raise IngestApiError.apiParseError(error, self.provider)
         except Exception as error:
             traceback.print_exc()
-            raise IngestApiError(error)
+            raise IngestApiError(error, self.provider)
 
     def get_url(self, endpoint):
         """Get API url for given endpoint."""


### PR DESCRIPTION
Major changes in this PR:
* Administrators will get every caught ingest error in Notifications and activity streams (and email)
* Notifying user in the messages will be "System"

So after the merge the following existing features will work as expected:
* The notifications can be turned on/off per Provider on settings
* Administrators can opt out from ingest error emails in user settings