### PR TITLE
Duplication of content and ingest items

### DIFF
--- a/apps/archive/archive.py
+++ b/apps/archive/archive.py
@@ -38,7 +38,7 @@ from copy import copy
 import superdesk
 import logging
 from apps.common.models.utils import get_model
-from ..item_lock.models.item import ItemModel
+from apps.item_lock.models.item import ItemModel
 
 logger = logging.getLogger(__name__)
 
@@ -293,10 +293,10 @@ class ArchiveService(BaseService):
         return new_doc['guid']
 
     def duplicate_versions(self, old_id, new_doc):
-        lookup = {}
-        lookup['guid'] = old_id
+        lookup = {'guid': old_id}
         old_versions = get_resource_service('archive_versions').get(req=None, lookup=lookup)
 
+        new_versions = []
         for old_version in old_versions:
             old_version['_id_document'] = new_doc['_id']
             del old_version['_id']
@@ -304,7 +304,9 @@ class ArchiveService(BaseService):
             old_version['unique_name'] = new_doc['unique_name']
             old_version['unique_id'] = new_doc['unique_id']
             old_version['versioncreated'] = utcnow()
-            get_resource_service('archive_versions').post([old_version])
+            new_versions.append(old_version)
+
+        get_resource_service('archive_versions').post(new_versions)
 
     def can_edit(self, item, user_id):
         """

--- a/apps/archive/archive.py
+++ b/apps/archive/archive.py
@@ -277,6 +277,7 @@ class ArchiveService(BaseService):
         self.duplicate_versions(original_doc['guid'], new_doc)
         if new_doc.get('state') != 'submitted':
             get_resource_service('tasks').patch(new_doc['_id'], {'state': 'submitted'})
+        return new_doc['guid']
 
     def duplicate_versions(self, old_id, new_doc):
         lookup = {}

--- a/apps/archive/archive.py
+++ b/apps/archive/archive.py
@@ -305,8 +305,8 @@ class ArchiveService(BaseService):
             old_version['unique_id'] = new_doc['unique_id']
             old_version['versioncreated'] = utcnow()
             new_versions.append(old_version)
-
-        get_resource_service('archive_versions').post(new_versions)
+        if new_versions:
+            get_resource_service('archive_versions').post(new_versions)
 
     def can_edit(self, item, user_id):
         """

--- a/apps/archive/archive.py
+++ b/apps/archive/archive.py
@@ -266,6 +266,17 @@ class ArchiveService(BaseService):
         doc.update(old)
         return res
 
+    def duplicate_content(self, original_doc):
+        if original_doc.get('type', '') == 'composite':
+            for groups in original_doc.get('groups'):
+                if groups.get('id') != 'root':
+                    associations = groups.get('refs', [])
+                    for assoc in associations:
+                        item, item_id, endpoint = superdesk.get_resource_service('packages').get_associated_item(assoc)
+                        assoc['residRef'] = assoc['guid'] = self.duplicate_content(item)
+
+        return self.duplicate_item(original_doc)
+
     def duplicate_item(self, original_doc):
         new_doc = original_doc.copy()
         del new_doc['_id']

--- a/apps/archive/archive.py
+++ b/apps/archive/archive.py
@@ -268,18 +268,20 @@ class ArchiveService(BaseService):
 
     def duplicate_item(self, original_doc):
         new_doc = original_doc.copy()
-        del new_doc['_id']
-        del new_doc['guid']
+        if '_id' in new_doc:
+            del new_doc['_id']
+        if 'guid' in new_doc:
+            del new_doc['guid']
         item_model = get_model(ItemModel)
         on_duplicate_item(new_doc)
         item_model.create([new_doc])
-        self.duplicate_versions(original_doc['_id'], new_doc['_id'])
+        self.duplicate_versions(original_doc['guid'], new_doc['guid'])
         if new_doc.get('state') != 'submitted':
-            get_resource_service('archive').patch(new_doc['_id'], {'state': 'submitted'})
+            get_resource_service('tasks').patch(new_doc['_id'], {'state': 'submitted'})
 
     def duplicate_versions(self, old_id, new_id):
         lookup = {}
-        lookup['_id_document'] = old_id
+        lookup['guid'] = old_id
         old_versions = get_resource_service('archive_versions').get(req=None, lookup=lookup)
 
         for old_version in old_versions:

--- a/apps/archive/archive.py
+++ b/apps/archive/archive.py
@@ -272,8 +272,10 @@ class ArchiveService(BaseService):
                 if groups.get('id') != 'root':
                     associations = groups.get('refs', [])
                     for assoc in associations:
-                        item, item_id, endpoint = superdesk.get_resource_service('packages').get_associated_item(assoc)
-                        assoc['residRef'] = assoc['guid'] = self.duplicate_content(item)
+                        if assoc.get('residRef'):
+                            item, item_id, endpoint = \
+                                superdesk.get_resource_service('packages').get_associated_item(assoc)
+                            assoc['residRef'] = assoc['guid'] = self.duplicate_content(item)
 
         return self.duplicate_item(original_doc)
 

--- a/apps/archive/archive_ingest.py
+++ b/apps/archive/archive_ingest.py
@@ -101,7 +101,6 @@ class ArchiveIngestService(BaseService):
 
                 push_notification('item:fetch', item=str(ingest_doc.get('_id')))
 
-
         return [doc.get('guid') for doc in docs]
 
 

--- a/apps/archive/archive_ingest.py
+++ b/apps/archive/archive_ingest.py
@@ -23,11 +23,8 @@ from apps.tasks import send_to
 from superdesk.errors import SuperdeskApiError, InvalidStateTransitionError
 from superdesk.utc import utcnow
 from superdesk.resource import Resource
-<<<<<<< HEAD
 from .common import generate_guid, generate_unique_id_and_name, GUID_TAG
-=======
 from .common import get_user, generate_guid, generate_unique_id_and_name, GUID_NEWSML, GUID_TAG
->>>>>>> (feat)Duplication multiple fetch from ingest
 from superdesk.services import BaseService
 from .archive import SOURCE as ARCHIVE
 from superdesk.workflow import is_workflow_state_transition_valid
@@ -35,10 +32,7 @@ from apps.content import LINKED_IN_PACKAGES, PACKAGE
 from superdesk.notification import push_notification
 STATE_FETCHED = 'fetched'
 FAMILY_ID = 'family_id'
-<<<<<<< HEAD
 INGEST_ID = 'ingest_id'
-=======
->>>>>>> (feat)Duplication multiple fetch from ingest
 
 logger = get_task_logger(__name__)
 
@@ -63,13 +57,17 @@ def create_from_ingest_doc(dest_doc, source_doc):
 
     dest_doc[config.VERSION] = 1
     dest_doc[config.CONTENT_STATE] = STATE_FETCHED
+    dest_doc['ingest_id'] = source_doc['_id']
+    dest_doc[FAMILY_ID] = source_doc['_id']
 
     dest_doc[FAMILY_ID] = generate_guid(type=GUID_TAG)
     # generate a whole new id
     new_id = generate_guid(type=GUID_NEWSML)
     dest_doc['_id'] = new_id
     dest_doc['guid'] = new_id
+    # Save the id of the original
     dest_doc['ingest_id'] = source_doc['_id']
+    dest_doc[FAMILY_ID] = source_doc['_id']
     generate_unique_id_and_name(dest_doc)
 
 class ArchiveIngestService(BaseService):

--- a/apps/archive/archive_ingest.py
+++ b/apps/archive/archive_ingest.py
@@ -34,8 +34,6 @@ STATE_FETCHED = 'fetched'
 FAMILY_ID = 'family_id'
 INGEST_ID = 'ingest_id'
 
-logger = get_task_logger(__name__)
-
 class ArchiveIngestResource(Resource):
     resource_methods = ['POST']
     item_methods = []

--- a/apps/archive/archive_ingest.py
+++ b/apps/archive/archive_ingest.py
@@ -23,15 +23,13 @@ from apps.tasks import send_to
 from superdesk.errors import SuperdeskApiError, InvalidStateTransitionError
 from superdesk.utc import utcnow
 from superdesk.resource import Resource
-from .common import generate_guid, generate_unique_id_and_name, GUID_TAG
+from .common import generate_guid, generate_unique_id_and_name, GUID_TAG, FAMILY_ID, INGEST_ID
 from superdesk.services import BaseService
 from .archive import SOURCE as ARCHIVE
 from superdesk.workflow import is_workflow_state_transition_valid
 from apps.content import LINKED_IN_PACKAGES, PACKAGE
 from superdesk.notification import push_notification
 STATE_FETCHED = 'fetched'
-FAMILY_ID = 'family_id'
-INGEST_ID = 'ingest_id'
 
 
 class ArchiveIngestResource(Resource):

--- a/apps/archive/archive_ingest.py
+++ b/apps/archive/archive_ingest.py
@@ -23,7 +23,11 @@ from apps.tasks import send_to
 from superdesk.errors import SuperdeskApiError, InvalidStateTransitionError
 from superdesk.utc import utcnow
 from superdesk.resource import Resource
+<<<<<<< HEAD
 from .common import generate_guid, generate_unique_id_and_name, GUID_TAG
+=======
+from .common import get_user, generate_guid, generate_unique_id_and_name, GUID_NEWSML, GUID_TAG
+>>>>>>> (feat)Duplication multiple fetch from ingest
 from superdesk.services import BaseService
 from .archive import SOURCE as ARCHIVE
 from superdesk.workflow import is_workflow_state_transition_valid
@@ -31,8 +35,12 @@ from apps.content import LINKED_IN_PACKAGES, PACKAGE
 from superdesk.notification import push_notification
 STATE_FETCHED = 'fetched'
 FAMILY_ID = 'family_id'
+<<<<<<< HEAD
 INGEST_ID = 'ingest_id'
+=======
+>>>>>>> (feat)Duplication multiple fetch from ingest
 
+logger = get_task_logger(__name__)
 
 class ArchiveIngestResource(Resource):
     resource_methods = ['POST']
@@ -44,6 +52,26 @@ class ArchiveIngestResource(Resource):
     privileges = {'POST': 'ingest_move'}
 
 
+def create_from_ingest_doc(dest_doc, source_doc):
+    """Create a new archive item using values from given source doc.
+
+    :param dest_doc: doc which gets persisted into archive collection
+    :param source_doc: doc which is fetched from ingest collection
+    """
+    for key, val in source_doc.items():
+        dest_doc.setdefault(key, val)
+
+    dest_doc[config.VERSION] = 1
+    dest_doc[config.CONTENT_STATE] = STATE_FETCHED
+
+    dest_doc[FAMILY_ID] = generate_guid(type=GUID_TAG)
+    # generate a whole new id
+    new_id = generate_guid(type=GUID_NEWSML)
+    dest_doc['_id'] = new_id
+    dest_doc['guid'] = new_id
+    dest_doc['ingest_id'] = source_doc['_id']
+    generate_unique_id_and_name(dest_doc)
+
 class ArchiveIngestService(BaseService):
 
     def create(self, docs, **kwargs):
@@ -51,6 +79,7 @@ class ArchiveIngestService(BaseService):
         for doc in docs:
             ingest_doc = superdesk.get_resource_service('ingest').find_one(req=None, _id=doc.get('guid'))
             if not ingest_doc:
+<<<<<<< HEAD
                 # see if it is in archive, if it is duplicate it
                 archived_doc = superdesk.get_resource_service(ARCHIVE).find_one(req=None, _id=doc.get('guid'))
                 if archived_doc:
@@ -60,6 +89,15 @@ class ArchiveIngestService(BaseService):
                 else:
                     msg = 'Fail to found ingest item with guid: %s' % doc.get('guid')
                     raise SuperdeskApiError.notFoundError(msg)
+=======
+                # all items that are in archive already should have a famil
+                if FAMILY_ID in doc:
+                    # call tolga's thing
+                    pass
+#                msg = 'Fail to found ingest item with guid: %s' % doc.get('guid')
+#                raise SuperdeskApiError.notFoundError(msg)
+
+>>>>>>> (feat)Duplication multiple fetch from ingest
             else:
                 # We are fetching from ingest
                 if not is_workflow_state_transition_valid('fetch_as_from_ingest', ingest_doc[config.CONTENT_STATE]):

--- a/apps/archive/common.py
+++ b/apps/archive/common.py
@@ -47,6 +47,9 @@ def on_create_item(docs):
         set_default_state(doc, 'draft')
         doc.setdefault('_id', doc['guid'])
 
+        if not 'family_id' in doc:
+            doc['family_id'] = generate_guid(type=GUID_TAG)
+
 
 def on_duplicate_item(doc):
     """Make sure duplicated item has basic fields populated."""

--- a/apps/archive/common.py
+++ b/apps/archive/common.py
@@ -30,6 +30,8 @@ from superdesk.errors import SuperdeskApiError, IdentifierGenerationError
 GUID_TAG = 'tag'
 GUID_NEWSML = 'newsml'
 ARCHIVE_MEDIA = 'archive_media'
+FAMILY_ID = 'family_id'
+INGEST_ID = 'ingest_id'
 
 
 def on_create_item(docs):

--- a/apps/archive/common.py
+++ b/apps/archive/common.py
@@ -44,6 +44,9 @@ def on_create_item(docs):
         if 'unique_id' not in doc:
             generate_unique_id_and_name(doc)
 
+        if 'family_id' not in doc:
+            doc['family_id'] = doc['guid']
+
         set_default_state(doc, 'draft')
         doc.setdefault('_id', doc['guid'])
 

--- a/apps/archive/common.py
+++ b/apps/archive/common.py
@@ -50,9 +50,6 @@ def on_create_item(docs):
         set_default_state(doc, 'draft')
         doc.setdefault('_id', doc['guid'])
 
-        if not 'family_id' in doc:
-            doc['family_id'] = generate_guid(type=GUID_TAG)
-
 
 def on_duplicate_item(doc):
     """Make sure duplicated item has basic fields populated."""

--- a/apps/archive/common.py
+++ b/apps/archive/common.py
@@ -50,6 +50,9 @@ def on_create_item(docs):
         set_default_state(doc, 'draft')
         doc.setdefault('_id', doc['guid'])
 
+        if not 'family_id' in doc:
+            doc['family_id'] = generate_guid(type=GUID_TAG)
+
 
 def on_duplicate_item(doc):
     """Make sure duplicated item has basic fields populated."""

--- a/apps/archive/common.py
+++ b/apps/archive/common.py
@@ -48,6 +48,16 @@ def on_create_item(docs):
         doc.setdefault('_id', doc['guid'])
 
 
+def on_duplicate_item(doc):
+    """Make sure duplicated item has basic fields populated."""
+    doc['guid'] = generate_guid(type=GUID_NEWSML)
+
+    if 'unique_id' not in doc:
+        generate_unique_id_and_name(doc)
+
+    doc.setdefault('_id', doc['guid'])
+
+
 def update_dates_for(doc):
     for item in ['firstcreated', 'versioncreated']:
         doc.setdefault(item, utcnow())

--- a/apps/archive/common.py
+++ b/apps/archive/common.py
@@ -47,9 +47,6 @@ def on_create_item(docs):
         set_default_state(doc, 'draft')
         doc.setdefault('_id', doc['guid'])
 
-        if not 'family_id' in doc:
-            doc['family_id'] = generate_guid(type=GUID_TAG)
-
 
 def on_duplicate_item(doc):
     """Make sure duplicated item has basic fields populated."""

--- a/apps/archive/user_content.py
+++ b/apps/archive/user_content.py
@@ -44,12 +44,12 @@ superdesk.workflow_state('draft')
 
 superdesk.workflow_action(
     name='fetch_from_content',
-    include_states=['fetched', 'routed', 'submitted', 'in-progress'],
+    include_states=['fetched', 'routed', 'submitted', 'in_progress'],
     privileges=['archive']
 )
 
 superdesk.workflow_action(
     name='fetch_as_from_content',
-    include_states=['fetched', 'routed', 'submitted', 'in-progress'],
+    include_states=['fetched', 'routed', 'submitted', 'in_progress'],
     privileges=['archive']
 )

--- a/apps/content.py
+++ b/apps/content.py
@@ -41,6 +41,14 @@ metadata_schema = {
     'version': {
         'type': 'integer'
     },
+    'ingest_id': {
+        'type': 'string',
+        'mapping': not_analyzed
+    },
+    'family_id': {
+        'type': 'string',
+        'mapping': not_analyzed
+    },
 
     # Audit Information
     'original_creator': Resource.rel('users'),

--- a/features/archive_ingest.feature
+++ b/features/archive_ingest.feature
@@ -77,8 +77,7 @@ Feature: Archive Ingest
             "_items": [
                 {
                     "_version": 1,
-                    "guid": "tag:reuters.com,2014:newsml_LYNXMPEA6F0MS",
-                    "linked_in_packages": [{"package": "tag:reuters.com,2014:newsml_KBN0FL0NM"}],
+                    "linked_in_packages": [{}],
                     "state": "fetched",
                     "type": "picture"
                 },
@@ -87,43 +86,38 @@ Feature: Archive Ingest
                     "groups": [
                         {
                             "refs": [
-                                {"itemClass": "icls:text", "residRef": "tag:reuters.com,2014:newsml_KBN0FL0NN"},
-                                {"itemClass": "icls:picture", "residRef": "tag:reuters.com,2014:newsml_LYNXMPEA6F13M"},
-                                {"itemClass": "icls:picture", "residRef": "tag:reuters.com,2014:newsml_LYNXMPEA6F0MS"},
-                                {"itemClass": "icls:picture", "residRef": "tag:reuters.com,2014:newsml_LYNXMPEA6F0MT"}
+                                {"itemClass": "icls:text"},
+                                {"itemClass": "icls:picture"},
+                                {"itemClass": "icls:picture"},
+                                {"itemClass": "icls:picture"}
                             ]
                         },
-                        {"refs": [{"itemClass": "icls:text", "residRef": "tag:reuters.com,2014:newsml_KBN0FL0ZP"}]}
+                        {"refs": [{"itemClass": "icls:text"}]}
                     ],
-                    "guid": "tag:reuters.com,2014:newsml_KBN0FL0NM",
                     "state": "fetched",
                     "type": "composite"
                 },
                 {
                     "_version": 1,
-                    "guid": "tag:reuters.com,2014:newsml_LYNXMPEA6F0MT",
-                    "linked_in_packages": [{"package": "tag:reuters.com,2014:newsml_KBN0FL0NM"}],
+                    "linked_in_packages": [{}],
                     "state": "fetched",
                     "type": "picture"
                 },
                 {
                     "_version": 1,
-                    "guid": "tag:reuters.com,2014:newsml_KBN0FL0ZP",
-                    "linked_in_packages": [{"package": "tag:reuters.com,2014:newsml_KBN0FL0NM"}],
+                    "linked_in_packages": [{}],
                     "state": "fetched",
                     "type": "text"
                 },
                 {
                     "_version": 1,
-                    "guid": "tag:reuters.com,2014:newsml_LYNXMPEA6F13M",
-                    "linked_in_packages": [{"package": "tag:reuters.com,2014:newsml_KBN0FL0NM"}],
+                    "linked_in_packages": [{}],
                     "state": "fetched",
                     "type": "picture"
                 },
                 {
                     "_version": 1,
-                    "guid": "tag:reuters.com,2014:newsml_KBN0FL0NN",
-                    "linked_in_packages": [{"package": "tag:reuters.com,2014:newsml_KBN0FL0NM"}],
+                    "linked_in_packages": [{}],
                     "state": "fetched",
                     "type": "text"
                 }

--- a/features/archive_ingest.feature
+++ b/features/archive_ingest.feature
@@ -45,7 +45,8 @@ Feature: Archive Ingest
         "guid": "tag:reuters.com,0000:newsml_GM1EA7M13RP01"
         }
         """
-        And we get "/archive/tag:reuters.com,0000:newsml_GM1EA7M13RP01"
+        Then we get "_id"
+        When we get "/archive/#_id#"
         Then we get existing resource
 		"""
         {
@@ -166,11 +167,12 @@ Feature: Archive Ingest
         """
         {"guid": "tag:reuters.com,2014:newsml_LOVEA6M0L7U2E", "desk": "#desks._id#"}
         """
-        And we post to "/archive/tag:reuters.com,2014:newsml_LOVEA6M0L7U2E/lock"
+        Then we get "_id"
+        When we post to "/archive/#_id#/lock"
         """
         {}
         """
-        And we patch "/archive/tag:reuters.com,2014:newsml_LOVEA6M0L7U2E"
+        And we patch "/archive/#_id#"
         """
         {"headline": "test 2"}
         """

--- a/features/content_spike.feature
+++ b/features/content_spike.feature
@@ -45,7 +45,11 @@ Feature: Content Spiking
             """
             {"guid": "tag:reuters.com,2014:newsml_LOVEA6M0L7U2E"}
             """
-        When we spike "tag:reuters.com,2014:newsml_LOVEA6M0L7U2E"
+        Then we get "_id"
+        When we spike fetched item
+        """
+        {"_id": "#_id#"}
+        """
         Then we get OK response
 
     @auth

--- a/features/duplication.feature
+++ b/features/duplication.feature
@@ -80,24 +80,6 @@ Feature: Duplication
         		]}
         """
 
-<<<<<<< HEAD
-=======
-    @auth
-    Scenario: Duplicate a content item on the same desk
-        Given empty "archive"
-        Given "desks"
-        """
-        [{"name": "Sports"}]
-        """
-        Given "archive"
-        """
-        [{"guid": "tag:example.com,0000:newsml_BRE9A605", "task": {"desk": "#desks._id#"}}]
-        """
-        When we post to "/archive_ingest"
-        """
-        {"guid": "tag:example.com,0000:newsml_BRE9A605"}
-        """
->>>>>>> (feat)Duplication work on tests
 
 
     @auth
@@ -131,6 +113,56 @@ Feature: Duplication
           {"task": {"desk": "#desks._id#", "user": "#CONTEXT_USER_ID#"}}
         """
         When we post to "/archive_ingest"
+        """
+        {"guid": "123", "desk": "#desks._id#"}
+        """
+
+        Then we get "_id"
+        When we get "/archive/#_id#?version=all"
+        Then we get list with 4 items
+
+    @auth
+    Scenario: Duplicate a content with history for a non-submitted item
+        Given empty "archive"
+        Given "desks"
+        """
+        [{"name": "Sports"}]
+        """
+        Given "archive"
+	    """
+        [{"type":"text", "headline": "test1", "guid": "123", "original_creator": "abc", "state": "draft"}]
+        """
+        When we patch given
+        """
+        {"headline": "test2"}
+        """
+        And we patch latest
+        """
+        {"headline": "test3"}
+        """
+        Then we get updated response
+        """
+        {"headline": "test3"}
+        """
+       	And we get version 3
+       	When we get "/archive/123?version=all"
+        Then we get list with 3 items
+        When we post to "/archive_ingest"
+        """
+        {"guid": "123", "desk": "#desks._id#"}
+        """
+
+        Then we get "_id"
+        When we get "/archive/#_id#?version=all"
+        Then we get list with 4 items
+
+    @auth
+    @provider
+    Scenario: Duplicate a composite item and expect the twice the number of items as the original
+    	Given empty "ingest"
+        Given empty "archive"
+    	When we fetch from "reuters" ingest "tag:reuters.com,2014:newsml_KBN0FL0NM"
+        And we post to "/archive_ingest"
         """
         {
         "guid": "tag:reuters.com,2014:newsml_KBN0FL0NM"

--- a/features/duplication.feature
+++ b/features/duplication.feature
@@ -80,6 +80,24 @@ Feature: Duplication
         		]}
         """
 
+<<<<<<< HEAD
+=======
+    @auth
+    Scenario: Duplicate a content item on the same desk
+        Given empty "archive"
+        Given "desks"
+        """
+        [{"name": "Sports"}]
+        """
+        Given "archive"
+        """
+        [{"guid": "tag:example.com,0000:newsml_BRE9A605", "task": {"desk": "#desks._id#"}}]
+        """
+        When we post to "/archive_ingest"
+        """
+        {"guid": "tag:example.com,0000:newsml_BRE9A605"}
+        """
+>>>>>>> (feat)Duplication work on tests
 
 
     @auth

--- a/features/duplication.feature
+++ b/features/duplication.feature
@@ -80,24 +80,7 @@ Feature: Duplication
         		]}
         """
 
-    @auth
-    Scenario: Duplicate a content item on the same desk
-        Given empty "archive"
-        Given "desks"
-        """
-        [{"name": "Sports"}]
-        """
-        Given "archive"
-        """
-        [{"guid": "tag:example.com,0000:newsml_BRE9A605", "task": {"desk": "#desks._id#"}}]
-        """
-        When we post to "/archive_ingest"
-        """
-        {"guid": "tag:example.com,0000:newsml_BRE9A605"}
-        """
 
-        When we get "/archive?q=#desks._id#"
-        Then we get list with 2 items
 
     @auth
     Scenario: Duplicate a content with history for a submitted item
@@ -171,17 +154,4 @@ Feature: Duplication
 
         Then we get "_id"
         When we get "/archive/#_id#?version=all"
-        Then we get list with 3 items
-
-#    @auth
-#    Scenario: Duplicated versions are identical
-#
-#    @auth
-#    Scenario: Duplicated item fields are identical
-#
-#    @auth
-#    Scenario: Create a new archive item with family id populated
-#
-#    @auth
-#    Scenario: Search the duplicated items
-#    - search with family_id:xxx to return all related items
+        Then we get list with 4 items

--- a/features/duplication.feature
+++ b/features/duplication.feature
@@ -132,44 +132,14 @@ Feature: Duplication
         """
         When we post to "/archive_ingest"
         """
-        {"guid": "123", "desk": "#desks._id#"}
+        {
+        "guid": "tag:reuters.com,2014:newsml_KBN0FL0NM"
+        }
         """
-
         Then we get "_id"
-        When we get "/archive/#_id#?version=all"
-        Then we get list with 4 items
-
-    @auth
-    Scenario: Duplicate a content with history for a non-submitted item
-        Given empty "archive"
-        Given "desks"
-        """
-        [{"name": "Sports"}]
-        """
-        Given "archive"
-	    """
-        [{"type":"text", "headline": "test1", "guid": "123", "original_creator": "abc", "state": "draft"}]
-        """
-        When we patch given
-        """
-        {"headline": "test2"}
-        """
-        And we patch latest
-        """
-        {"headline": "test3"}
-        """
-        Then we get updated response
-        """
-        {"headline": "test3"}
-        """
-       	And we get version 3
-       	When we get "/archive/123?version=all"
-        Then we get list with 3 items
         When we post to "/archive_ingest"
         """
-        {"guid": "123", "desk": "#desks._id#"}
+        {"guid": "#_id#"}
         """
-
-        Then we get "_id"
-        When we get "/archive/#_id#?version=all"
-        Then we get list with 4 items
+        When we get "/archive"
+        Then we get list with 12 items

--- a/features/duplication.feature
+++ b/features/duplication.feature
@@ -36,14 +36,15 @@ Feature: Duplication
             """
             [{"guid": "tag:reuters.com,2014:newsml_LOVEA6M0L7U2E"}]
             """
-        And we post to "/archive_ingest"
+        When we post to "/archive_ingest"
             """
             {"guid": "tag:reuters.com,2014:newsml_LOVEA6M0L7U2E", "desk": "#desks._id#"}
             """
-        And we get "/archive"
-        Then we get existing resource
-        Then we get "family_id" populated
-        Then we get "ingest_id" populated
+        When we get "/archive"
+        Then we get list with 1 items
+        """
+        {"_items": [{"family_id": "tag:reuters.com,2014:newsml_LOVEA6M0L7U2E", "ingest_id": "tag:reuters.com,2014:newsml_LOVEA6M0L7U2E"}]}
+        """
 
     @auth
     @provider
@@ -57,14 +58,16 @@ Feature: Duplication
             """
             [{"guid": "tag:reuters.com,2014:newsml_LOVEA6M0L7U2E"}]
             """
-        And we post to "/archive_ingest"
+        When we post to "/archive_ingest"
             """
             {"guid": "tag:reuters.com,2014:newsml_LOVEA6M0L7U2E", "desk": "#desks._id#"}
             """
-        And we get "/archive"
-        Then we get existing resource
-        Then we get "family_id"
-        And we post to "/archive_ingest"
+        When we get "/archive"
+        Then we get list with 1 items
+            """
+            {"_items": [{"family_id": "tag:reuters.com,2014:newsml_LOVEA6M0L7U2E", "ingest_id": "tag:reuters.com,2014:newsml_LOVEA6M0L7U2E"}]}
+            """
+        When we post to "/archive_ingest"
             """
             {"guid": "tag:reuters.com,2014:newsml_LOVEA6M0L7U2E", "desk": "#desks._id#"}
             """
@@ -72,23 +75,25 @@ Feature: Duplication
         Then we get list with 2 items
         """
         {"_items": [
-        		{"family_id": "#family_id"},
-        		{"family_id": "#family_id"}
+        		{"family_id": "tag:reuters.com,2014:newsml_LOVEA6M0L7U2E"},
+        		{"family_id": "tag:reuters.com,2014:newsml_LOVEA6M0L7U2E"}
+        		]}
         """
 
     @auth
     Scenario: Duplicate a content item on the same desk
+        Given empty "archive"
         Given "desks"
         """
         [{"name": "Sports"}]
         """
         Given "archive"
         """
-        [{"guid": "tag:example.com,0000:newsml_BRE9A605"}]
+        [{"guid": "tag:example.com,0000:newsml_BRE9A605", "task": {"desk": "#desks._id#"}}]
         """
-        And we post to "/archive_ingest"
+        When we post to "/archive_ingest"
         """
-        {"guid": "tag:example.com,0000:newsml_BRE9A605", "desk": "#desks._id#"}
+        {"guid": "tag:example.com,0000:newsml_BRE9A605"}
         """
 
         When we get "/archive?q=#desks._id#"
@@ -96,18 +101,15 @@ Feature: Duplication
 
     @auth
     Scenario: Duplicate a content with history for a submitted item
+        Given empty "archive"
         Given "desks"
         """
         [{"name": "Sports"}]
         """
-        Given the "archive"
+        Given "archive"
 	    """
         [{"type":"text", "headline": "test1", "guid": "123", "original_creator": "abc", "state": "submitted"}]
         """
-        And we get "/archive"
-        Then we get existing resource
-        Then we get "family_id"
-        When we switch user
         When we patch given
         """
         {"headline": "test2"}
@@ -118,34 +120,35 @@ Feature: Duplication
         """
         Then we get updated response
         """
-        {"headline": "test3", "version_creator": "#user._id#"}
+        {"headline": "test3"}
         """
        	And we get version 3
        	When we get "/archive/123?version=all"
         Then we get list with 3 items
-        And we post to "/archive_ingest"
+        When we patch "/tasks/123"
         """
-        {"guid": "tag:example.com,0000:newsml_BRE9A605", "desk": "#desks._id#"}
+          {"task": {"desk": "#desks._id#", "user": "#CONTEXT_USER_ID#"}}
+        """
+        When we post to "/archive_ingest"
+        """
+        {"guid": "123", "desk": "#desks._id#"}
         """
 
-        When we get "guid"
-        Then we get "/archive/#guid?version=all"
-        Then we get list with 3 items
+        Then we get "_id"
+        When we get "/archive/#_id#?version=all"
+        Then we get list with 4 items
 
     @auth
     Scenario: Duplicate a content with history for a non-submitted item
+        Given empty "archive"
         Given "desks"
         """
         [{"name": "Sports"}]
         """
-        Given the "archive"
+        Given "archive"
 	    """
-        [{"type":"text", "headline": "test1", "guid": "123", "original_creator": "abc", "state": "in-progress"}]
+        [{"type":"text", "headline": "test1", "guid": "123", "original_creator": "abc", "state": "draft"}]
         """
-        And we get "/archive"
-        Then we get existing resource
-        Then we get "family_id"
-        When we switch user
         When we patch given
         """
         {"headline": "test2"}
@@ -156,29 +159,29 @@ Feature: Duplication
         """
         Then we get updated response
         """
-        {"headline": "test3", "version_creator": "#user._id#"}
+        {"headline": "test3"}
         """
        	And we get version 3
        	When we get "/archive/123?version=all"
         Then we get list with 3 items
-        And we post to "/archive_ingest"
+        When we post to "/archive_ingest"
         """
-        {"guid": "tag:example.com,0000:newsml_BRE9A605", "desk": "#desks._id#"}
+        {"guid": "123", "desk": "#desks._id#"}
         """
 
-        When we get "guid"
-        Then we get "/archive/#guid?version=all"
-        Then we get list with 4 items
+        Then we get "_id"
+        When we get "/archive/#_id#?version=all"
+        Then we get list with 3 items
 
-    @auth
-    Scenario: Duplicated versions are identical
-
-    @auth
-    Scenario: Duplicated item fields are identical
-
-    @auth
-    Scenario: Create a new archive item with family id populated
-
-    @auth
-    Scenario: Search the duplicated items
-    - search with family_id:xxx to return all related items
+#    @auth
+#    Scenario: Duplicated versions are identical
+#
+#    @auth
+#    Scenario: Duplicated item fields are identical
+#
+#    @auth
+#    Scenario: Create a new archive item with family id populated
+#
+#    @auth
+#    Scenario: Search the duplicated items
+#    - search with family_id:xxx to return all related items

--- a/features/duplication.feature
+++ b/features/duplication.feature
@@ -1,0 +1,184 @@
+Feature: Duplication
+
+    @auth
+    @provider
+    Scenario: Fetch same ingest item to a desk twice
+        Given empty "archive"
+        Given "desks"
+            """
+            [{"name": "Sports"}]
+            """
+        And ingest from "reuters"
+            """
+            [{"guid": "tag:reuters.com,2014:newsml_LOVEA6M0L7U2E"}]
+            """
+        When we post to "/archive_ingest"
+            """
+            {"guid": "tag:reuters.com,2014:newsml_LOVEA6M0L7U2E", "desk": "#desks._id#"}
+            """
+        And we post to "/archive_ingest"
+            """
+            {"guid": "tag:reuters.com,2014:newsml_LOVEA6M0L7U2E", "desk": "#desks._id#"}
+            """
+        Then we get new resource
+        When we get "/archive?q=#desks._id#"
+        Then we get list with 2 items
+
+    @auth
+    @provider
+    Scenario: Fetch ingest item to a desk with ingest and family ids
+        Given empty "archive"
+        Given "desks"
+            """
+            [{"name": "Sports"}]
+            """
+        And ingest from "reuters"
+            """
+            [{"guid": "tag:reuters.com,2014:newsml_LOVEA6M0L7U2E"}]
+            """
+        And we post to "/archive_ingest"
+            """
+            {"guid": "tag:reuters.com,2014:newsml_LOVEA6M0L7U2E", "desk": "#desks._id#"}
+            """
+        And we get "/archive"
+        Then we get existing resource
+        Then we get "family_id" populated
+        Then we get "ingest_id" populated
+
+    @auth
+    @provider
+    Scenario: Fetch ingest item twice with same family ids
+        Given empty "archive"
+        Given "desks"
+            """
+            [{"name": "Sports"}]
+            """
+        And ingest from "reuters"
+            """
+            [{"guid": "tag:reuters.com,2014:newsml_LOVEA6M0L7U2E"}]
+            """
+        And we post to "/archive_ingest"
+            """
+            {"guid": "tag:reuters.com,2014:newsml_LOVEA6M0L7U2E", "desk": "#desks._id#"}
+            """
+        And we get "/archive"
+        Then we get existing resource
+        Then we get "family_id"
+        And we post to "/archive_ingest"
+            """
+            {"guid": "tag:reuters.com,2014:newsml_LOVEA6M0L7U2E", "desk": "#desks._id#"}
+            """
+        When we get "/archive?q=#desks._id#"
+        Then we get list with 2 items
+        """
+        {"_items": [
+        		{"family_id": "#family_id"},
+        		{"family_id": "#family_id"}
+        """
+
+    @auth
+    Scenario: Duplicate a content item on the same desk
+        Given "desks"
+        """
+        [{"name": "Sports"}]
+        """
+        Given "archive"
+        """
+        [{"guid": "tag:example.com,0000:newsml_BRE9A605"}]
+        """
+        And we post to "/archive_ingest"
+        """
+        {"guid": "tag:example.com,0000:newsml_BRE9A605", "desk": "#desks._id#"}
+        """
+
+        When we get "/archive?q=#desks._id#"
+        Then we get list with 2 items
+
+    @auth
+    Scenario: Duplicate a content with history for a submitted item
+        Given "desks"
+        """
+        [{"name": "Sports"}]
+        """
+        Given the "archive"
+	    """
+        [{"type":"text", "headline": "test1", "guid": "123", "original_creator": "abc", "state": "submitted"}]
+        """
+        And we get "/archive"
+        Then we get existing resource
+        Then we get "family_id"
+        When we switch user
+        When we patch given
+        """
+        {"headline": "test2"}
+        """
+        And we patch latest
+        """
+        {"headline": "test3"}
+        """
+        Then we get updated response
+        """
+        {"headline": "test3", "version_creator": "#user._id#"}
+        """
+       	And we get version 3
+       	When we get "/archive/123?version=all"
+        Then we get list with 3 items
+        And we post to "/archive_ingest"
+        """
+        {"guid": "tag:example.com,0000:newsml_BRE9A605", "desk": "#desks._id#"}
+        """
+
+        When we get "guid"
+        Then we get "/archive/#guid?version=all"
+        Then we get list with 3 items
+
+    @auth
+    Scenario: Duplicate a content with history for a non-submitted item
+        Given "desks"
+        """
+        [{"name": "Sports"}]
+        """
+        Given the "archive"
+	    """
+        [{"type":"text", "headline": "test1", "guid": "123", "original_creator": "abc", "state": "in-progress"}]
+        """
+        And we get "/archive"
+        Then we get existing resource
+        Then we get "family_id"
+        When we switch user
+        When we patch given
+        """
+        {"headline": "test2"}
+        """
+        And we patch latest
+        """
+        {"headline": "test3"}
+        """
+        Then we get updated response
+        """
+        {"headline": "test3", "version_creator": "#user._id#"}
+        """
+       	And we get version 3
+       	When we get "/archive/123?version=all"
+        Then we get list with 3 items
+        And we post to "/archive_ingest"
+        """
+        {"guid": "tag:example.com,0000:newsml_BRE9A605", "desk": "#desks._id#"}
+        """
+
+        When we get "guid"
+        Then we get "/archive/#guid?version=all"
+        Then we get list with 4 items
+
+    @auth
+    Scenario: Duplicated versions are identical
+
+    @auth
+    Scenario: Duplicated item fields are identical
+
+    @auth
+    Scenario: Create a new archive item with family id populated
+
+    @auth
+    Scenario: Search the duplicated items
+    - search with family_id:xxx to return all related items

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -1191,7 +1191,7 @@ def when_we_get_invisible_stages(context, no_of_stages):
 
 @then('we get {no_of_stages} visible stages')
 def when_we_get_visible_stages(context, no_of_stages):
-    we get'URL_PREFIX']):
+    with context.app.test_request_context(context.app.config['URL_PREFIX']):
         stages = get_resource_service('stages').get_stages_by_visibility(is_visible=True)
         assert len(stages) == int(no_of_stages)
 

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -1203,6 +1203,7 @@ def when_we_get_invisible_stages_for_user(context, no_of_stages):
         stages = get_resource_service('users').get_invisible_stages(data['user'])
         assert len(stages) == int(no_of_stages)
 
+
 @then('we get "{field_name}" populated')
 def then_field_is_populated(context, field_name):
     resp = parse_json_response(context.response)

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -1191,7 +1191,7 @@ def when_we_get_invisible_stages(context, no_of_stages):
 
 @then('we get {no_of_stages} visible stages')
 def when_we_get_visible_stages(context, no_of_stages):
-    with context.app.test_request_context(context.app.config['URL_PREFIX']):
+    we get'URL_PREFIX']):
         stages = get_resource_service('stages').get_stages_by_visibility(is_visible=True)
         assert len(stages) == int(no_of_stages)
 
@@ -1202,3 +1202,8 @@ def when_we_get_invisible_stages_for_user(context, no_of_stages):
     with context.app.test_request_context(context.app.config['URL_PREFIX']):
         stages = get_resource_service('users').get_invisible_stages(data['user'])
         assert len(stages) == int(no_of_stages)
+
+@then('we get "{field_name}" populated')
+def then_field_is_populated(context, field_name):
+    resp = parse_json_response(context.response)
+    assert resp[field_name].get('user', None) is not None, 'item is not populated'

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -993,6 +993,17 @@ def step_impl_when_spike_url(context, item_id):
                                             data='{"state": "spiked"}', headers=headers)
 
 
+@when('we spike fetched item')
+def step_impl_when_spike_fetched_item(context):
+    data = json.loads(apply_placeholders(context, context.text))
+    item_id = data["_id"]
+    res = get_res('/archive/' + item_id, context)
+    headers = if_match(context, res.get('_etag'))
+
+    context.response = context.client.patch(get_prefixed_url(context.app, '/archive/spike/' + item_id),
+                                            data='{"state": "spiked"}', headers=headers)
+
+
 @when('we unspike "{item_id}"')
 def step_impl_when_unspike_url(context, item_id):
     res = get_res('/archive/' + item_id, context)


### PR DESCRIPTION
[SD-1290] As a User, I want the ability to fetch previously fetched content.
[SD-815] As a user, I want to duplicate content items

Major changes

* Fetch action allowed from both ingest and archive.
* Fetch is allowed more than once from ingest.
* New guids are created with each ingest.
* Original guids are saved in new field ingest_id
* New field family_id allows related items to be identified.
* All versions are duplicated along with content items (deep copy)