### PR TITLE
fix(preferences): fix server error when getting preferences

### DIFF
--- a/apps/preferences.py
+++ b/apps/preferences.py
@@ -112,6 +112,8 @@ class PreferencesService(BaseService):
 
     def find_one(self, req, **lookup):
         session_doc = super().find_one(req, **lookup)
+        if not session_doc:  # fetching old session preferences using new session
+            return
         user_doc = get_resource_service('users').find_one(req=None, _id=session_doc['user'])
         self.enhance_document_with_default_prefs(session_doc, user_doc)
         self.enhance_document_with_user_privileges(session_doc, user_doc)

--- a/features/preferences.feature
+++ b/features/preferences.feature
@@ -9,6 +9,10 @@ Feature: User preferences
         {"_error": {"message": "The method is not allowed for the requested URL.", "code": 405}, "_status": "ERR"}
         """
 
+    @auth
+    Scenario: Fetch old preferences using new session
+      When we get "/preferences/54d876dc102454a053a6d786"
+      Then we get error 404
 
     @auth
     Scenario: Create new preference


### PR DESCRIPTION
client has an old preferences id, it will wait for auth but then it
will fetch old preferences id using new auth token - so it will pass
auth but the old session is not there anymore..

sentry 2688